### PR TITLE
Add NFL calendar picker, fix Eagles calendar, Easter eggs & visitor tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,8 @@
     <link rel="stylesheet" href="./styles/musicSection.css" />
     <link rel="stylesheet" href="./styles/projectStyles.css" />
     <link rel="stylesheet" href="./styles/cryforhelp.css" />
+    <link rel="stylesheet" href="./styles/nfl-calendar.css" />
+    <link rel="stylesheet" href="./styles/easter-eggs.css" />
 
     <link
       rel="stylesheet"
@@ -205,6 +207,27 @@
                 <p class="birds_accent">
                   <span class="birds_accent">GO BIRDS! 🦅</span>
                 </p>
+
+                <!-- Primary: direct ICS download powered by ESPN live data -->
+                <div class="eagles-direct-download">
+                  <p class="eagles-direct-label">📅 Add all games instantly — no email needed:</p>
+                  <button id="eagles-direct-ics" class="btn eagles-ics-btn">
+                    <i class="fas fa-download"></i> Download Eagles Schedule (.ics)
+                  </button>
+                  <p class="eagles-direct-note">Works with Apple Calendar, Google Calendar &amp; Outlook · Always up-to-date from ESPN</p>
+                  <div id="eagles-direct-status" class="eagles-direct-status"></div>
+                  <div id="eagles-import-guide" class="eagles-import-guide" hidden>
+                    <strong>How to import:</strong>
+                    <ul>
+                      <li>🍎 <b>Apple Calendar</b>: Double-click the downloaded file</li>
+                      <li>📅 <b>Google Calendar</b>: Settings → Import → Upload the file</li>
+                      <li>📧 <b>Outlook</b>: File → Open &amp; Export → Import/Export</li>
+                    </ul>
+                  </div>
+                </div>
+
+                <div class="eagles-divider"><span>or get calendar invites via email</span></div>
+
                 <form id="inviteForm" class="invite_form">
                   <div class="form-group" id="formGroup">
                     <div class="marquee-text">
@@ -231,6 +254,44 @@
                     <span id="responseText"></span>
                   </div>
                 </form>
+              </div>
+            </div>
+          </div>
+
+          <!-- NFL Team Calendar Picker -->
+          <div class="nfl-calendar-wrapper row">
+            <div class="padd_15 nfl-calendar-section" style="width:100%">
+              <h3 class="nfl-section-title">🏈 Add Any NFL Team to Your Calendar</h3>
+              <p class="nfl-section-sub">
+                Pick one or more teams — schedules are fetched live from ESPN and exported as a standard .ics file that works everywhere.
+              </p>
+
+              <div class="nfl-toolbar">
+                <button class="nfl-toolbar-btn" id="nfl-select-all-btn">Select All 32</button>
+                <button class="nfl-toolbar-btn" id="nfl-clear-btn">Clear</button>
+                <span class="nfl-selected-count" id="nfl-selected-count">No teams selected</span>
+              </div>
+
+              <div class="nfl-teams-grid" id="nfl-teams-grid"></div>
+
+              <div class="nfl-actions">
+                <button class="nfl-btn nfl-btn-primary" id="nfl-download-ics" disabled>
+                  <i class="fas fa-download"></i> Download .ics
+                </button>
+                <button class="nfl-btn nfl-btn-ghost" id="nfl-clear-btn-2">
+                  <i class="fas fa-times"></i> Clear
+                </button>
+              </div>
+
+              <div id="nfl-status"></div>
+
+              <div id="nfl-import-guide" class="nfl-import-guide" hidden>
+                <p>How to import into your calendar:</p>
+                <ul>
+                  <li>🍎 <strong>Apple Calendar</strong>: Double-click the .ics file</li>
+                  <li>📅 <strong>Google Calendar</strong>: Settings ⚙️ → Import → Upload file</li>
+                  <li>📧 <strong>Outlook</strong>: File → Open &amp; Export → Import/Export</li>
+                </ul>
               </div>
             </div>
           </div>
@@ -462,5 +523,8 @@
 
     <script src="./scripts/script.js"></script>
     <script src="./scripts/style-switcher.js"></script>
+    <script src="./scripts/nfl-calendar.js"></script>
+    <script src="./scripts/easter-eggs.js"></script>
+    <script src="./scripts/visitor-tracker.js"></script>
   </body>
 </html>

--- a/scripts/calendarInvite.js
+++ b/scripts/calendarInvite.js
@@ -1,63 +1,191 @@
-document.addEventListener('DOMContentLoaded', () => {
-    const form = document.getElementById("inviteForm");
-    const emailInput = document.getElementById("email");
-    const submitButton = document.getElementById("submitButton");
-    const formGroup = document.getElementById("formGroup");
+/**
+ * Eagles Calendar Invite
+ * Primary:   Download an ICS file built in real-time from ESPN's public API
+ * Secondary: Email invite via Google Apps Script (requires user email)
+ */
+document.addEventListener("DOMContentLoaded", () => {
+  // ── Email-based invite (secondary path) ──────────────────────────────────
+  const form              = document.getElementById("inviteForm");
+  const emailInput        = document.getElementById("email");
+  const submitButton      = document.getElementById("submitButton");
+  const formGroup         = document.getElementById("formGroup");
+  const responseMessageDiv = document.getElementById("responseMessage");
+  const responseIcon      = document.getElementById("responseIcon");
+  const responseText      = document.getElementById("responseText");
 
-    const responseMessageDiv = document.getElementById("responseMessage");
-    const responseIcon = document.getElementById("responseIcon");
-    const responseText = document.getElementById("responseText");
+  const SCRIPT_URL =
+    "https://script.google.com/macros/s/AKfycbyYmu3bPV2n79YBC1uSPphErMxAGGrAmwLbR-QzqLtu71LrxemqDldZaj0K-w-FVciFVg/exec";
 
-    const SCRIPT_URL = "https://script.google.com/macros/s/AKfycbyYmu3bPV2n79YBC1uSPphErMxAGGrAmwLbR-QzqLtu71LrxemqDldZaj0K-w-FVciFVg/exec";
+  if (form) {
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
 
-    form.addEventListener('submit', (e) => {
-        e.preventDefault();
+      submitButton.disabled = true;
+      submitButton.classList.add("loading");
+      formGroup.classList.add("loading");
+      emailInput.disabled = true;
+      responseMessageDiv.classList.remove("visible", "success", "error");
 
-
-        submitButton.disabled = true;
-        submitButton.classList.add('loading');
-        formGroup.classList.add('loading');
-
-        emailInput.disabled = true;
-
-        responseMessageDiv.classList.remove('visible', 'success', 'error');
-
-        // 2. Make the fetch request to the Google Apps Script
-        fetch(SCRIPT_URL, {
-            method: 'POST',
-            body: new URLSearchParams({
-                email: emailInput.value
-            })
+      fetch(SCRIPT_URL, {
+        method: "POST",
+        redirect: "follow",
+        body: new URLSearchParams({ email: emailInput.value }),
+      })
+        .then((r) => {
+          if (!r.ok) throw new Error(`HTTP ${r.status}`);
+          return r.json();
         })
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error(`Network response was not ok: ${response.statusText}`);
-                }
-                return response.json();
-            })
-            .then(data => {
-                responseText.textContent = data.message;
-                if (data.status === 'success') {
-                    responseMessageDiv.classList.add('success');
-                    responseIcon.className = 'fa-solid fa-circle-check';
-                    form.reset();
-                } else {
-                    responseMessageDiv.classList.add('error');
-                    responseIcon.className = 'fa-solid fa-circle-xmark';
-                }
-            })
-            .catch(error => {
-                console.error("Fetch Error:", error);
-                responseMessageDiv.classList.add('error');
-                responseIcon.className = 'fa-solid fa-triangle-exclamation';
-                responseText.textContent = 'An unexpected error occurred. Please try again.';
-            })
-            .finally(() => {
-                submitButton.disabled = false;
-                submitButton.classList.remove('loading');
-                formGroup.classList.remove('loading');
-                emailInput.disabled = false
-                responseMessageDiv.classList.add('visible');
-            });
+        .then((data) => {
+          responseText.textContent = data.message;
+          responseIcon.className =
+            data.status === "success"
+              ? "fa-solid fa-circle-check"
+              : "fa-solid fa-circle-xmark";
+          responseMessageDiv.classList.add(
+            data.status === "success" ? "success" : "error"
+          );
+          if (data.status === "success") form.reset();
+        })
+        .catch(() => {
+          responseMessageDiv.classList.add("error");
+          responseIcon.className = "fa-solid fa-triangle-exclamation";
+          responseText.textContent =
+            "Couldn't reach the server. Try the direct download below instead!";
+        })
+        .finally(() => {
+          submitButton.disabled = false;
+          submitButton.classList.remove("loading");
+          formGroup.classList.remove("loading");
+          emailInput.disabled = false;
+          responseMessageDiv.classList.add("visible");
+        });
     });
+  }
+
+  // ── Direct ICS download (primary path) ───────────────────────────────────
+  const EAGLES_TEAM_ID = "21"; // ESPN team ID for Philadelphia Eagles
+
+  const directBtn   = document.getElementById("eagles-direct-ics");
+  const directStatus = document.getElementById("eagles-direct-status");
+
+  if (!directBtn) return;
+
+  directBtn.addEventListener("click", async () => {
+    directBtn.disabled = true;
+    directBtn.innerHTML = `<i class="fas fa-spinner fa-spin"></i> Fetching schedule…`;
+    setDirectStatus("Fetching live schedule from ESPN…", "loading");
+
+    try {
+      const data  = await fetchEaglesSchedule();
+      const games = parseEaglesGames(data);
+
+      if (games.length === 0) {
+        setDirectStatus("No upcoming games found. Check back later!", "error");
+        return;
+      }
+
+      const ics = buildICS(games);
+      triggerDownload(ics, "eagles-2025-schedule.ics");
+      setDirectStatus(
+        `✅ Downloaded ${games.length} Eagles games! Import the file into your calendar app.`,
+        "success"
+      );
+
+      // Show import guide
+      const guide = document.getElementById("eagles-import-guide");
+      if (guide) guide.hidden = false;
+    } catch (err) {
+      console.error("Eagles ICS error:", err);
+      setDirectStatus(
+        "❌ Could not reach ESPN. Check your connection and try again.",
+        "error"
+      );
+    } finally {
+      directBtn.disabled = false;
+      directBtn.innerHTML = `<i class="fas fa-download"></i> Download Eagles Schedule (.ics)`;
+    }
+  });
+
+  function setDirectStatus(msg, type) {
+    if (!directStatus) return;
+    directStatus.textContent = msg;
+    directStatus.className = `eagles-direct-status status-${type}`;
+  }
+
+  // ── ESPN helpers ──────────────────────────────────────────────────────────
+  async function fetchEaglesSchedule() {
+    const url = `https://site.api.espn.com/apis/site/v2/sports/football/nfl/teams/${EAGLES_TEAM_ID}/schedule`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`ESPN API ${res.status}`);
+    return res.json();
+  }
+
+  function parseEaglesGames(data) {
+    return (data.events || [])
+      .filter((e) => e.competitions?.[0])
+      .map((e) => {
+        const comp    = e.competitions[0];
+        const home    = comp.competitors?.find((c) => c.homeAway === "home");
+        const away    = comp.competitors?.find((c) => c.homeAway === "away");
+        const venue   = comp.venue || {};
+        const homeAbbr = home?.team?.abbreviation ?? "HOME";
+        const awayAbbr = away?.team?.abbreviation ?? "AWAY";
+        const isHomeGame = home?.team?.id === EAGLES_TEAM_ID;
+        return {
+          uid:      e.id,
+          start:    new Date(e.date),
+          summary:  `🦅 Eagles: ${awayAbbr} @ ${homeAbbr}${isHomeGame ? " 🏟" : ""}`,
+          description: `Philadelphia Eagles — ${e.season?.year ?? "2025"} NFL Season\n${e.name ?? ""}`,
+          location: [venue.fullName, venue.address?.city, venue.address?.state]
+            .filter(Boolean)
+            .join(", "),
+        };
+      });
+  }
+
+  // ── ICS builder ───────────────────────────────────────────────────────────
+  function toUTC(date) {
+    return date.toISOString().replace(/[-:.]/g, "").slice(0, 15) + "Z";
+  }
+
+  function buildICS(games) {
+    const lines = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//Eagles 2025 Schedule//AK Portfolio//EN",
+      "CALSCALE:GREGORIAN",
+      "METHOD:PUBLISH",
+      "X-WR-CALNAME:🦅 Eagles 2025 Season",
+      "X-WR-TIMEZONE:America/New_York",
+    ];
+
+    games.forEach((g) => {
+      const end = new Date(g.start.getTime() + 3 * 60 * 60 * 1000);
+      lines.push(
+        "BEGIN:VEVENT",
+        `UID:${g.uid}@eagles-ak-portfolio`,
+        `DTSTART:${toUTC(g.start)}`,
+        `DTEND:${toUTC(end)}`,
+        `SUMMARY:${g.summary}`,
+        `DESCRIPTION:${g.description.replace(/\n/g, "\\n")}`,
+        `LOCATION:${g.location}`,
+        "END:VEVENT"
+      );
+    });
+
+    lines.push("END:VCALENDAR");
+    return lines.join("\r\n");
+  }
+
+  function triggerDownload(content, filename) {
+    const blob = new Blob([content], { type: "text/calendar;charset=utf-8" });
+    const url  = URL.createObjectURL(blob);
+    const a    = Object.assign(document.createElement("a"), {
+      href: url, download: filename,
+    });
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
 });

--- a/scripts/easter-eggs.js
+++ b/scripts/easter-eggs.js
@@ -1,0 +1,234 @@
+/**
+ * Easter Eggs 🥚
+ * 1. Console art on load
+ * 2. Konami Code → confetti party
+ * 3. Logo clicked 5× → "HIRE ME" overlay
+ * 4. Idle 45s → cheeky message
+ * 5. Secret word "hire" typed anywhere → flash animation
+ */
+
+// ─── 1. Console art ───────────────────────────────────────────────────────────
+(function printConsoleArt() {
+  const gold  = "color:#dfa70a;font-weight:bold;";
+  const white = "color:#e9e9e9;font-size:13px;";
+  const cyan  = "color:#00bfff;font-size:13px;";
+  const green = "color:#33ff99;font-size:13px;font-weight:bold;";
+
+  console.log(
+    "%c" +
+    "    _    _  __\n" +
+    "   / \\  | |/ /\n" +
+    "  / _ \\ | ' / \n" +
+    " / ___ \\| . \\ \n" +
+    "/_/   \\_\\_|\\_\\\n",
+    "color:#dfa70a;font-family:monospace;font-size:16px;font-weight:bold;"
+  );
+  console.log("%c👀 Oh hey, you found the DevTools — respect.", white);
+  console.log("%c🚀 Built by Anil Kumar — Full Stack & DevOps Engineer", green);
+  console.log("%c📧 karapaanilkumar@gmail.com", cyan);
+  console.log(
+    "%c🔗 linkedin.com/in/anil-kumar-karapa/",
+    cyan
+  );
+  console.log(
+    "%c💡 Pro tip: try the Konami code on this page ↑↑↓↓←→←→BA",
+    gold
+  );
+})();
+
+// ─── 2. Konami Code ───────────────────────────────────────────────────────────
+(function konamiCode() {
+  const SEQUENCE = [
+    "ArrowUp","ArrowUp","ArrowDown","ArrowDown",
+    "ArrowLeft","ArrowRight","ArrowLeft","ArrowRight",
+    "b","a",
+  ];
+  let idx = 0;
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === SEQUENCE[idx]) {
+      idx++;
+      if (idx === SEQUENCE.length) {
+        idx = 0;
+        triggerPartyMode();
+      }
+    } else {
+      idx = e.key === SEQUENCE[0] ? 1 : 0;
+    }
+  });
+
+  function triggerPartyMode() {
+    // Toast
+    const toast = document.createElement("div");
+    toast.className = "ee-toast";
+    toast.innerHTML =
+      "<span>🎉 DEVELOPER MODE ACTIVATED 🎉</span><br><small>Konami code unlocked!</small>";
+    document.body.appendChild(toast);
+    setTimeout(() => toast.classList.add("ee-toast-show"), 10);
+    setTimeout(() => {
+      toast.classList.remove("ee-toast-show");
+      setTimeout(() => toast.remove(), 400);
+    }, 3000);
+
+    // Big confetti burst
+    burstConfetti(120);
+  }
+})();
+
+// ─── 3. Logo 5× click ─────────────────────────────────────────────────────────
+(function logoClickEasterEgg() {
+  const logo = document.querySelector(".aside .logo a");
+  if (!logo) return;
+
+  let clicks = 0;
+  let timer;
+
+  logo.addEventListener("click", (e) => {
+    e.preventDefault();
+    clicks++;
+    clearTimeout(timer);
+    timer = setTimeout(() => (clicks = 0), 1200);
+
+    if (clicks >= 5) {
+      clicks = 0;
+      showHireMeOverlay();
+    }
+  });
+
+  function showHireMeOverlay() {
+    if (document.getElementById("hire-me-overlay")) return;
+
+    const overlay = document.createElement("div");
+    overlay.id = "hire-me-overlay";
+    overlay.innerHTML = `
+      <div class="hire-me-box">
+        <div class="hire-me-emoji">🚀</div>
+        <h2 class="hire-me-title">HIRE ME!</h2>
+        <p class="hire-me-subtitle">Seriously though 🥺</p>
+        <p class="hire-me-sub2">Full Stack · DevOps · Cloud · Enthusiastic Human</p>
+        <a href="mailto:karapaanilkumar@gmail.com" class="hire-me-btn">
+          📧 Let's Talk
+        </a>
+        <button class="hire-me-close" id="hire-me-close">Maybe later</button>
+      </div>
+    `;
+    document.body.appendChild(overlay);
+    setTimeout(() => overlay.classList.add("hire-me-visible"), 10);
+    burstConfetti(80);
+
+    document.getElementById("hire-me-close").addEventListener("click", () => {
+      overlay.classList.remove("hire-me-visible");
+      setTimeout(() => overlay.remove(), 400);
+    });
+    overlay.addEventListener("click", (e) => {
+      if (e.target === overlay) {
+        overlay.classList.remove("hire-me-visible");
+        setTimeout(() => overlay.remove(), 400);
+      }
+    });
+  }
+})();
+
+// ─── 4. Idle message ──────────────────────────────────────────────────────────
+(function idleMessage() {
+  const IDLE_MS = 45000;
+  const MESSAGES = [
+    "👀 Still here? I like your dedication.",
+    "☕ Go grab a coffee — I'll still be here.",
+    "🤔 Thinking about reaching out?",
+    "🎯 Psst… the email link is right up top.",
+    "💡 Fun fact: This site runs on 0 frameworks. Just vibes.",
+  ];
+  let idleTimer;
+  let toast;
+  let msgIdx = 0;
+
+  function resetIdle() {
+    clearTimeout(idleTimer);
+    if (toast) {
+      toast.classList.remove("ee-toast-show");
+    }
+    idleTimer = setTimeout(showIdleMsg, IDLE_MS);
+  }
+
+  function showIdleMsg() {
+    if (document.hidden) return;
+    if (toast) toast.remove();
+    toast = document.createElement("div");
+    toast.className = "ee-toast ee-idle-toast";
+    toast.textContent = MESSAGES[msgIdx % MESSAGES.length];
+    msgIdx++;
+    document.body.appendChild(toast);
+    setTimeout(() => toast.classList.add("ee-toast-show"), 10);
+    setTimeout(() => {
+      toast.classList.remove("ee-toast-show");
+      setTimeout(() => { if (toast) toast.remove(); toast = null; }, 400);
+    }, 4500);
+  }
+
+  ["mousemove","keydown","scroll","click","touchstart"].forEach((ev) =>
+    document.addEventListener(ev, resetIdle, { passive: true })
+  );
+  resetIdle();
+})();
+
+// ─── 5. Secret word "hire" typed anywhere ─────────────────────────────────────
+(function secretWordEgg() {
+  const TARGET = "hire";
+  let buf = "";
+
+  document.addEventListener("keydown", (e) => {
+    if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") return;
+    buf = (buf + e.key).slice(-TARGET.length).toLowerCase();
+    if (buf === TARGET) {
+      buf = "";
+      flashHireGlow();
+    }
+  });
+
+  function flashHireGlow() {
+    const flash = document.createElement("div");
+    flash.className = "ee-hire-flash";
+    flash.textContent = "💼 Hiring? Let's connect!";
+    document.body.appendChild(flash);
+    setTimeout(() => flash.classList.add("ee-hire-flash-show"), 10);
+    setTimeout(() => {
+      flash.classList.remove("ee-hire-flash-show");
+      setTimeout(() => flash.remove(), 600);
+    }, 2200);
+  }
+})();
+
+// ─── Shared confetti helper ────────────────────────────────────────────────────
+function burstConfetti(count = 60) {
+  const colors = [
+    "#dfa70a","#ff6b6b","#4ecdc4","#45b7d1","#f9ca24",
+    "#6c5ce7","#fd79a8","#00b894","#e17055","#74b9ff",
+  ];
+  const cx = window.innerWidth / 2;
+  const cy = window.innerHeight / 2;
+
+  for (let i = 0; i < count; i++) {
+    const dot = document.createElement("div");
+    dot.className = "ee-confetti-dot";
+    const color = colors[Math.floor(Math.random() * colors.length)];
+    const angle = Math.random() * Math.PI * 2;
+    const dist  = 150 + Math.random() * 250;
+    const tx    = Math.cos(angle) * dist;
+    const ty    = Math.sin(angle) * dist;
+    const size  = 6 + Math.random() * 8;
+
+    Object.assign(dot.style, {
+      left: cx + "px",
+      top:  cy + "px",
+      width: size + "px",
+      height: size + "px",
+      background: color,
+      borderRadius: Math.random() > 0.5 ? "50%" : "2px",
+      "--tx": tx + "px",
+      "--ty": ty + "px",
+    });
+    document.body.appendChild(dot);
+    setTimeout(() => dot.remove(), 1400);
+  }
+}

--- a/scripts/nfl-calendar.js
+++ b/scripts/nfl-calendar.js
@@ -1,0 +1,283 @@
+/**
+ * NFL Team Calendar Picker
+ * Fetches real-time schedules from the ESPN public API (no key needed)
+ * and generates ICS files for any selected teams.
+ */
+document.addEventListener("DOMContentLoaded", () => {
+  // ─── Team roster with ESPN IDs ────────────────────────────────────────────
+  const NFL_TEAMS = [
+    { id: "22", name: "Arizona Cardinals",    abbr: "ARI", color: "#97233F", division: "NFC West"  },
+    { id: "1",  name: "Atlanta Falcons",      abbr: "ATL", color: "#A71930", division: "NFC South" },
+    { id: "33", name: "Baltimore Ravens",     abbr: "BAL", color: "#241773", division: "AFC North" },
+    { id: "2",  name: "Buffalo Bills",        abbr: "BUF", color: "#00338D", division: "AFC East"  },
+    { id: "29", name: "Carolina Panthers",    abbr: "CAR", color: "#0085CA", division: "NFC South" },
+    { id: "3",  name: "Chicago Bears",        abbr: "CHI", color: "#C83803", division: "NFC North" },
+    { id: "4",  name: "Cincinnati Bengals",   abbr: "CIN", color: "#FB4F14", division: "AFC North" },
+    { id: "5",  name: "Cleveland Browns",     abbr: "CLE", color: "#FF3C00", division: "AFC North" },
+    { id: "6",  name: "Dallas Cowboys",       abbr: "DAL", color: "#003594", division: "NFC East"  },
+    { id: "7",  name: "Denver Broncos",       abbr: "DEN", color: "#FB4F14", division: "AFC West"  },
+    { id: "8",  name: "Detroit Lions",        abbr: "DET", color: "#0076B6", division: "NFC North" },
+    { id: "9",  name: "Green Bay Packers",    abbr: "GB",  color: "#203731", division: "NFC North" },
+    { id: "34", name: "Houston Texans",       abbr: "HOU", color: "#03202F", division: "AFC South" },
+    { id: "11", name: "Indianapolis Colts",   abbr: "IND", color: "#002C5F", division: "AFC South" },
+    { id: "30", name: "Jacksonville Jaguars", abbr: "JAX", color: "#006778", division: "AFC South" },
+    { id: "12", name: "Kansas City Chiefs",   abbr: "KC",  color: "#E31837", division: "AFC West"  },
+    { id: "13", name: "Las Vegas Raiders",    abbr: "LV",  color: "#A5ACAF", division: "AFC West"  },
+    { id: "24", name: "Los Angeles Chargers", abbr: "LAC", color: "#0080C6", division: "AFC West"  },
+    { id: "14", name: "Los Angeles Rams",     abbr: "LAR", color: "#003594", division: "NFC West"  },
+    { id: "15", name: "Miami Dolphins",       abbr: "MIA", color: "#008E97", division: "AFC East"  },
+    { id: "16", name: "Minnesota Vikings",    abbr: "MIN", color: "#4F2683", division: "NFC North" },
+    { id: "17", name: "New England Patriots", abbr: "NE",  color: "#002244", division: "AFC East"  },
+    { id: "18", name: "New Orleans Saints",   abbr: "NO",  color: "#D3BC8D", division: "NFC South" },
+    { id: "19", name: "New York Giants",      abbr: "NYG", color: "#0B2265", division: "NFC East"  },
+    { id: "20", name: "New York Jets",        abbr: "NYJ", color: "#125740", division: "AFC East"  },
+    { id: "21", name: "Philadelphia Eagles",  abbr: "PHI", color: "#004C54", division: "NFC East"  },
+    { id: "23", name: "Pittsburgh Steelers",  abbr: "PIT", color: "#FFB612", division: "AFC North" },
+    { id: "25", name: "San Francisco 49ers",  abbr: "SF",  color: "#AA0000", division: "NFC West"  },
+    { id: "26", name: "Seattle Seahawks",     abbr: "SEA", color: "#002244", division: "NFC West"  },
+    { id: "27", name: "Tampa Bay Buccaneers", abbr: "TB",  color: "#D50A0A", division: "NFC South" },
+    { id: "10", name: "Tennessee Titans",     abbr: "TEN", color: "#4B92DB", division: "AFC South" },
+    { id: "28", name: "Washington Commanders",abbr: "WAS", color: "#5A1414", division: "NFC East"  },
+  ];
+
+  const DIVISIONS = [
+    "AFC East","AFC North","AFC South","AFC West",
+    "NFC East","NFC North","NFC South","NFC West",
+  ];
+
+  // ─── DOM refs ─────────────────────────────────────────────────────────────
+  const grid          = document.getElementById("nfl-teams-grid");
+  const downloadBtn   = document.getElementById("nfl-download-ics");
+  const clearBtn      = document.getElementById("nfl-clear-btn");
+  const selectAllBtn  = document.getElementById("nfl-select-all-btn");
+  const statusEl      = document.getElementById("nfl-status");
+  const countLabel    = document.getElementById("nfl-selected-count");
+  const importGuide   = document.getElementById("nfl-import-guide");
+
+  if (!grid) return;
+
+  // ─── State ────────────────────────────────────────────────────────────────
+  const selected = new Set();
+
+  // ─── Render team grid grouped by division ─────────────────────────────────
+  DIVISIONS.forEach((division) => {
+    const teamsInDiv = NFL_TEAMS.filter((t) => t.division === division);
+
+    const divWrapper = document.createElement("div");
+    divWrapper.className = "nfl-division-group";
+
+    const divTitle = document.createElement("h4");
+    divTitle.className = "nfl-division-title";
+    divTitle.textContent = division;
+    divWrapper.appendChild(divTitle);
+
+    const teamRow = document.createElement("div");
+    teamRow.className = "nfl-division-teams";
+
+    teamsInDiv.forEach((team) => {
+      const card = document.createElement("button");
+      card.className = "nfl-team-card";
+      card.dataset.id = team.id;
+      card.style.setProperty("--tc", team.color);
+      card.title = team.name;
+      card.innerHTML = `
+        <span class="nfl-check-icon"><i class="fas fa-check"></i></span>
+        <img
+          src="https://a.espncdn.com/i/teamlogos/nfl/500/${team.abbr.toLowerCase()}.png"
+          alt="${team.name} logo"
+          class="nfl-logo"
+          loading="lazy"
+          onerror="this.src=''"
+        />
+        <span class="nfl-abbr">${team.abbr}</span>
+      `;
+      card.addEventListener("click", () => toggleTeam(team, card));
+      teamRow.appendChild(card);
+    });
+
+    divWrapper.appendChild(teamRow);
+    grid.appendChild(divWrapper);
+  });
+
+  // ─── Toggle selection ─────────────────────────────────────────────────────
+  function toggleTeam(team, card) {
+    if (selected.has(team.id)) {
+      selected.delete(team.id);
+      card.classList.remove("nfl-selected");
+    } else {
+      selected.add(team.id);
+      card.classList.add("nfl-selected");
+    }
+    refreshUI();
+  }
+
+  function refreshUI() {
+    const n = selected.size;
+    countLabel.textContent =
+      n === 0 ? "No teams selected" : `${n} team${n !== 1 ? "s" : ""} selected`;
+    downloadBtn.disabled = n === 0;
+    if (statusEl) statusEl.textContent = "";
+    if (importGuide) importGuide.hidden = true;
+  }
+
+  // ─── Select all / clear ───────────────────────────────────────────────────
+  selectAllBtn?.addEventListener("click", () => {
+    NFL_TEAMS.forEach((team) => {
+      selected.add(team.id);
+      grid
+        .querySelector(`[data-id="${team.id}"]`)
+        ?.classList.add("nfl-selected");
+    });
+    refreshUI();
+  });
+
+  function clearAll() {
+    selected.clear();
+    grid
+      .querySelectorAll(".nfl-team-card.nfl-selected")
+      .forEach((c) => c.classList.remove("nfl-selected"));
+    refreshUI();
+  }
+
+  clearBtn?.addEventListener("click", clearAll);
+  document.getElementById("nfl-clear-btn-2")?.addEventListener("click", clearAll);
+
+  // ─── ESPN API helpers ─────────────────────────────────────────────────────
+  async function fetchTeamSchedule(teamId) {
+    const url = `https://site.api.espn.com/apis/site/v2/sports/football/nfl/teams/${teamId}/schedule`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`ESPN API ${res.status} for team ${teamId}`);
+    return res.json();
+  }
+
+  function parseGames(data, teamName) {
+    return (data.events || [])
+      .filter((e) => e.competitions?.[0])
+      .map((e) => {
+        const comp = e.competitions[0];
+        const home = comp.competitors?.find((c) => c.homeAway === "home");
+        const away = comp.competitors?.find((c) => c.homeAway === "away");
+        const venue = comp.venue || {};
+        const homeAbbr = home?.team?.abbreviation ?? "HOME";
+        const awayAbbr = away?.team?.abbreviation ?? "AWAY";
+        return {
+          uid: e.id,
+          start: new Date(e.date),
+          summary: `🏈 ${awayAbbr} @ ${homeAbbr}`,
+          description: `NFL ${e.season?.year ?? ""} — ${teamName}\n${e.name ?? ""}`,
+          location: [venue.fullName, venue.address?.city, venue.address?.state]
+            .filter(Boolean)
+            .join(", "),
+        };
+      });
+  }
+
+  // ─── ICS builder ──────────────────────────────────────────────────────────
+  function toUTC(date) {
+    return date.toISOString().replace(/[-:.]/g, "").slice(0, 15) + "Z";
+  }
+
+  function buildICS(games) {
+    const lines = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//NFL Schedule 2025//AK Portfolio//EN",
+      "CALSCALE:GREGORIAN",
+      "METHOD:PUBLISH",
+      "X-WR-CALNAME:NFL Schedule 2025",
+      "X-WR-TIMEZONE:America/New_York",
+    ];
+
+    games.forEach((g) => {
+      const end = new Date(g.start.getTime() + 3 * 60 * 60 * 1000);
+      lines.push(
+        "BEGIN:VEVENT",
+        `UID:${g.uid}@nfl-ak-portfolio`,
+        `DTSTART:${toUTC(g.start)}`,
+        `DTEND:${toUTC(end)}`,
+        `SUMMARY:${g.summary}`,
+        `DESCRIPTION:${g.description.replace(/\n/g, "\\n")}`,
+        `LOCATION:${g.location}`,
+        "END:VEVENT"
+      );
+    });
+
+    lines.push("END:VCALENDAR");
+    return lines.join("\r\n");
+  }
+
+  function triggerDownload(content, filename) {
+    const blob = new Blob([content], { type: "text/calendar;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = Object.assign(document.createElement("a"), {
+      href: url,
+      download: filename,
+    });
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+
+  function setStatus(msg, type = "info") {
+    if (!statusEl) return;
+    statusEl.textContent = msg;
+    statusEl.className = `nfl-status-msg nfl-status-${type}`;
+  }
+
+  // ─── Download handler ─────────────────────────────────────────────────────
+  downloadBtn?.addEventListener("click", async () => {
+    const teamIds = [...selected];
+    downloadBtn.disabled = true;
+    downloadBtn.innerHTML = `<i class="fas fa-spinner fa-spin"></i> Fetching from ESPN…`;
+    setStatus("⏳ Fetching live schedule data from ESPN…", "loading");
+
+    try {
+      const results = await Promise.all(
+        teamIds.map((id) => {
+          const team = NFL_TEAMS.find((t) => t.id === id);
+          return fetchTeamSchedule(id).then((data) =>
+            parseGames(data, team.name)
+          );
+        })
+      );
+
+      // Deduplicate by uid (shared games appear in both teams' schedules)
+      const seen = new Set();
+      const unique = results
+        .flat()
+        .filter((g) => {
+          if (seen.has(g.uid)) return false;
+          seen.add(g.uid);
+          return true;
+        })
+        .sort((a, b) => a.start - b.start);
+
+      if (unique.length === 0) {
+        setStatus("No upcoming games found for the selected teams.", "error");
+        return;
+      }
+
+      const ics = buildICS(unique);
+      const teamNames = teamIds
+        .map((id) => NFL_TEAMS.find((t) => t.id === id)?.abbr)
+        .join("-");
+      triggerDownload(ics, `nfl-schedule-${teamNames}-2025.ics`);
+
+      setStatus(
+        `✅ Downloaded ${unique.length} game${unique.length !== 1 ? "s" : ""} for ${teamIds.length} team${teamIds.length !== 1 ? "s" : ""}!`,
+        "success"
+      );
+      if (importGuide) importGuide.hidden = false;
+    } catch (err) {
+      console.error("NFL schedule fetch error:", err);
+      setStatus("❌ Could not fetch schedules from ESPN. Try again shortly.", "error");
+    } finally {
+      downloadBtn.disabled = false;
+      downloadBtn.innerHTML = `<i class="fas fa-download"></i> Download .ics`;
+      downloadBtn.disabled = selected.size === 0;
+    }
+  });
+
+  refreshUI();
+});

--- a/scripts/visitor-tracker.js
+++ b/scripts/visitor-tracker.js
@@ -1,0 +1,83 @@
+/**
+ * Visitor Tracker
+ * - Tracks per-device visit count & first-visit date via localStorage
+ * - Attempts a global hit count via CountAPI (free, no auth)
+ * - Renders a subtle badge in the footer area
+ */
+(function initVisitorTracker() {
+  // ── Per-device stats ──────────────────────────────────────────────────────
+  const VISIT_KEY       = "ak_portfolio_visits";
+  const FIRST_VISIT_KEY = "ak_portfolio_first_visit";
+
+  const now       = new Date();
+  const firstVisit = localStorage.getItem(FIRST_VISIT_KEY) || now.toISOString();
+  const visits     = parseInt(localStorage.getItem(VISIT_KEY) || "0", 10) + 1;
+
+  localStorage.setItem(VISIT_KEY, visits);
+  if (!localStorage.getItem(FIRST_VISIT_KEY)) {
+    localStorage.setItem(FIRST_VISIT_KEY, firstVisit);
+  }
+
+  const firstDate = new Date(firstVisit);
+  const firstStr  = firstDate.toLocaleDateString("en-US", {
+    month: "short", day: "numeric", year: "numeric",
+  });
+
+  // ── Inject badge ──────────────────────────────────────────────────────────
+  const badge = document.createElement("div");
+  badge.id = "visitor-badge";
+  badge.className = "visitor-badge";
+  badge.innerHTML = `
+    <span class="vb-pulse"></span>
+    <span class="vb-text">
+      Your visit <strong>#${visits}</strong>
+      <span class="vb-sep">·</span>
+      <span class="vb-global" id="vb-global" title="Total page views">
+        <i class="fas fa-globe" style="font-size:0.75rem;margin-right:2px;"></i>
+        <span id="vb-global-count">…</span> visitors
+      </span>
+    </span>
+  `;
+  document.body.appendChild(badge);
+
+  // First-visit tooltip
+  if (visits === 1) {
+    const tip = document.createElement("div");
+    tip.className = "vb-welcome-tip";
+    tip.textContent = "👋 Welcome! First time here?";
+    document.body.appendChild(tip);
+    setTimeout(() => tip.classList.add("vb-welcome-show"), 200);
+    setTimeout(() => {
+      tip.classList.remove("vb-welcome-show");
+      setTimeout(() => tip.remove(), 500);
+    }, 4000);
+  }
+
+  // ── Global counter via CountAPI ───────────────────────────────────────────
+  // Free tier — namespace + key uniquely identify this counter
+  const globalCountEl = document.getElementById("vb-global-count");
+  fetch("https://api.countapi.xyz/hit/ak-portfolio-anil-kumar-2025/visitors")
+    .then((r) => r.json())
+    .then((data) => {
+      if (data?.value && globalCountEl) {
+        globalCountEl.textContent = data.value.toLocaleString();
+      }
+    })
+    .catch(() => {
+      // silently fall back — don't show broken UI
+      const globalEl = document.getElementById("vb-global");
+      if (globalEl) globalEl.style.display = "none";
+    });
+
+  // ── Hide after scroll (unobtrusive) ──────────────────────────────────────
+  let hidden = false;
+  window.addEventListener("scroll", () => {
+    if (window.scrollY > 300 && !hidden) {
+      badge.classList.add("vb-faded");
+      hidden = true;
+    } else if (window.scrollY <= 100 && hidden) {
+      badge.classList.remove("vb-faded");
+      hidden = false;
+    }
+  }, { passive: true });
+})();

--- a/styles/eagles-form.css
+++ b/styles/eagles-form.css
@@ -201,3 +201,122 @@
   color: #dc3545;
   border: 1px solid #dc3545;
 }
+
+/* ─── Direct ICS Download (primary path) ─────────────────────────────── */
+.eagles-direct-download {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.eagles-direct-label {
+  font-size: 0.9rem !important;
+  color: var(--text-black-700);
+  padding-bottom: 0;
+  margin: 0;
+}
+
+.eagles-ics-btn {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--eagles-green);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.95rem;
+  padding: 0.7rem 1.4rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+
+.eagles-ics-btn:hover:not(:disabled) {
+  filter: brightness(1.15);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 76, 84, 0.4);
+}
+
+.eagles-ics-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.eagles-direct-note {
+  font-size: 0.78rem !important;
+  color: var(--text-black-700);
+  opacity: 0.8;
+  padding-bottom: 0;
+  margin: 0;
+}
+
+.eagles-direct-status {
+  font-size: 0.88rem;
+  font-weight: 500;
+  min-height: 1.2em;
+  transition: all 0.3s ease;
+  border-radius: 6px;
+}
+
+.eagles-direct-status.status-loading { color: var(--text-black-700); }
+.eagles-direct-status.status-success {
+  color: #28a745;
+  background: rgba(40, 167, 69, 0.1);
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgba(40, 167, 69, 0.3);
+}
+.eagles-direct-status.status-error {
+  color: #dc3545;
+  background: rgba(220, 53, 69, 0.1);
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgba(220, 53, 69, 0.3);
+}
+
+.eagles-import-guide {
+  background: rgba(0, 76, 84, 0.08);
+  border: 1px solid rgba(0, 76, 84, 0.25);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-size: 0.83rem;
+  margin-top: 0.25rem;
+}
+
+.eagles-import-guide strong {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: var(--text-black-900);
+}
+
+.eagles-import-guide ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.eagles-import-guide li { color: var(--text-black-700); }
+
+/* ─── Divider between primary and email path ──────────────────────────── */
+.eagles-divider {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0.75rem 0;
+  color: var(--text-black-700);
+}
+
+.eagles-divider::before,
+.eagles-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--bg-black-50);
+}
+
+.eagles-divider span {
+  font-size: 0.8rem;
+  white-space: nowrap;
+  opacity: 0.7;
+}

--- a/styles/easter-eggs.css
+++ b/styles/easter-eggs.css
@@ -1,0 +1,245 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   Easter Egg Styles
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* ─── Toast notification ───────────────────────────────────────────────────── */
+.ee-toast {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(20px);
+  background: #1a1a2e;
+  color: #fff;
+  padding: 0.9rem 1.6rem;
+  border-radius: 50px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-align: center;
+  z-index: 9999;
+  opacity: 0;
+  border: 2px solid var(--skin-color);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  transition: opacity 0.35s ease, transform 0.35s ease;
+  pointer-events: none;
+  line-height: 1.5;
+}
+
+.ee-toast.ee-toast-show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.ee-idle-toast {
+  border-color: #4ecdc4;
+  font-size: 0.9rem;
+}
+
+/* ─── Confetti dots ────────────────────────────────────────────────────────── */
+.ee-confetti-dot {
+  position: fixed;
+  pointer-events: none;
+  z-index: 9998;
+  animation: ee-confetti-fly 1.3s ease-out forwards;
+  transform-origin: center;
+}
+
+@keyframes ee-confetti-fly {
+  0%   { transform: translate(0, 0) rotate(0deg) scale(1); opacity: 1; }
+  100% { transform: translate(var(--tx), var(--ty)) rotate(720deg) scale(0.3); opacity: 0; }
+}
+
+/* ─── HIRE ME overlay ──────────────────────────────────────────────────────── */
+#hire-me-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.82);
+  backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  opacity: 0;
+  transition: opacity 0.35s ease;
+}
+
+#hire-me-overlay.hire-me-visible {
+  opacity: 1;
+}
+
+.hire-me-box {
+  background: #1a1a1a;
+  border: 2px solid var(--skin-color);
+  border-radius: 20px;
+  padding: 2.5rem 3rem;
+  text-align: center;
+  max-width: 420px;
+  width: 90%;
+  box-shadow: 0 0 60px rgba(223, 167, 10, 0.25);
+  transform: scale(0.85);
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+#hire-me-overlay.hire-me-visible .hire-me-box {
+  transform: scale(1);
+}
+
+.hire-me-emoji {
+  font-size: 3.5rem;
+  margin-bottom: 0.5rem;
+  animation: hire-me-bounce 1s ease-in-out infinite alternate;
+}
+
+@keyframes hire-me-bounce {
+  from { transform: translateY(0); }
+  to   { transform: translateY(-10px); }
+}
+
+.hire-me-title {
+  font-size: 2.5rem;
+  font-weight: 900;
+  color: var(--skin-color);
+  letter-spacing: 0.05em;
+  margin-bottom: 0.3rem;
+  text-shadow: 0 0 20px rgba(223, 167, 10, 0.5);
+}
+
+.hire-me-subtitle {
+  font-size: 1rem;
+  color: #e9e9e9;
+  margin-bottom: 0.2rem;
+  padding-bottom: 0;
+}
+
+.hire-me-sub2 {
+  font-size: 0.85rem;
+  color: #888;
+  margin-bottom: 1.5rem;
+  padding-bottom: 0;
+}
+
+.hire-me-btn {
+  display: inline-block;
+  background: var(--skin-color);
+  color: #111;
+  font-weight: 700;
+  padding: 0.75rem 2rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-size: 1rem;
+  transition: all 0.25s ease;
+  margin-bottom: 1rem;
+}
+
+.hire-me-btn:hover {
+  filter: brightness(1.15);
+  transform: translateY(-2px);
+}
+
+.hire-me-close {
+  display: block;
+  margin: 0 auto;
+  background: none;
+  border: none;
+  color: #666;
+  font-size: 0.85rem;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+}
+
+.hire-me-close:hover { color: #aaa; }
+
+/* ─── Secret "hire" flash ──────────────────────────────────────────────────── */
+.ee-hire-flash {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.8);
+  background: rgba(51, 255, 153, 0.95);
+  color: #111;
+  font-size: 1.1rem;
+  font-weight: 800;
+  padding: 0.85rem 2rem;
+  border-radius: 999px;
+  z-index: 9999;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease, transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  white-space: nowrap;
+}
+
+.ee-hire-flash.ee-hire-flash-show {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+/* ─── Visitor badge ────────────────────────────────────────────────────────── */
+.visitor-badge {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-black-100);
+  border: 1px solid var(--bg-black-50);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.8rem;
+  color: var(--text-black-700);
+  z-index: 900;
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
+}
+
+.visitor-badge.vb-faded {
+  opacity: 0;
+  transform: translateY(6px);
+  pointer-events: none;
+}
+
+.vb-pulse {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #2ed573;
+  animation: vb-pulse-anim 1.8s ease infinite;
+  flex-shrink: 0;
+}
+
+@keyframes vb-pulse-anim {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(46, 213, 115, 0.6); }
+  50%       { box-shadow: 0 0 0 5px rgba(46, 213, 115, 0); }
+}
+
+.vb-text { display: flex; align-items: center; gap: 0.35rem; }
+.vb-sep  { opacity: 0.4; }
+.vb-global { display: flex; align-items: center; gap: 0.2rem; }
+
+/* ─── Welcome tip ──────────────────────────────────────────────────────────── */
+.vb-welcome-tip {
+  position: fixed;
+  bottom: 3.5rem;
+  left: 1rem;
+  background: var(--skin-color);
+  color: #111;
+  font-size: 0.82rem;
+  font-weight: 700;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  z-index: 901;
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  pointer-events: none;
+}
+
+.vb-welcome-tip.vb-welcome-show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ─── Mobile hide visitor badge ────────────────────────────────────────────── */
+@media (max-width: 600px) {
+  .visitor-badge { bottom: 0.6rem; left: 0.6rem; font-size: 0.72rem; }
+}

--- a/styles/nfl-calendar.css
+++ b/styles/nfl-calendar.css
@@ -1,0 +1,265 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   NFL Team Calendar Picker
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.nfl-calendar-section {
+  padding: 2rem 1rem 3rem;
+}
+
+/* ─── Header ─────────────────────────────────────────────────────────────── */
+.nfl-section-title {
+  font-size: 1.5rem !important;
+  font-weight: 700 !important;
+  margin-bottom: 0.25rem;
+}
+
+.nfl-section-sub {
+  color: var(--text-black-700);
+  font-size: 0.95rem;
+  margin-bottom: 1.5rem;
+}
+
+/* ─── Toolbar ─────────────────────────────────────────────────────────────── */
+.nfl-toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.nfl-toolbar-btn {
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  border: 2px solid var(--skin-color);
+  background: transparent;
+  color: var(--skin-color);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+
+.nfl-toolbar-btn:hover {
+  background: var(--skin-color);
+  color: #111;
+}
+
+.nfl-selected-count {
+  font-size: 0.88rem;
+  color: var(--text-black-700);
+  margin-left: auto;
+}
+
+/* ─── Division Groups ─────────────────────────────────────────────────────── */
+.nfl-teams-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-bottom: 2rem;
+}
+
+.nfl-division-group {
+  background: var(--bg-black-100);
+  border: 1px solid var(--bg-black-50);
+  border-radius: 12px;
+  padding: 1rem 1rem 0.75rem;
+}
+
+.nfl-division-title {
+  font-size: 0.75rem !important;
+  font-weight: 700 !important;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--skin-color);
+  margin-bottom: 0.75rem;
+}
+
+.nfl-division-teams {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+/* ─── Team Card ───────────────────────────────────────────────────────────── */
+.nfl-team-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.3rem;
+
+  width: 70px;
+  padding: 0.5rem 0.4rem 0.4rem;
+  border-radius: 10px;
+  border: 2px solid var(--bg-black-50);
+  background: var(--bg-black-900);
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  outline: none;
+}
+
+.nfl-team-card:hover {
+  transform: translateY(-3px);
+  border-color: var(--tc, var(--skin-color));
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
+}
+
+.nfl-team-card.nfl-selected {
+  border-color: var(--tc, var(--skin-color));
+  background: color-mix(in srgb, var(--tc, var(--skin-color)) 12%, var(--bg-black-900));
+  box-shadow: 0 0 0 2px var(--tc, var(--skin-color)) inset;
+}
+
+/* checkmark */
+.nfl-check-icon {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--tc, var(--skin-color));
+  color: #fff;
+  font-size: 0.6rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: scale(0);
+  transition: all 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.nfl-team-card.nfl-selected .nfl-check-icon {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.nfl-logo {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  pointer-events: none;
+}
+
+.nfl-abbr {
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--text-black-900);
+  letter-spacing: 0.03em;
+}
+
+/* ─── Action bar ──────────────────────────────────────────────────────────── */
+.nfl-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-top: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.nfl-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.7rem 1.4rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: all 0.25s ease;
+}
+
+.nfl-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.nfl-btn-primary {
+  background: var(--skin-color);
+  color: #111;
+  border-color: var(--skin-color);
+}
+
+.nfl-btn-primary:hover:not(:disabled) {
+  filter: brightness(1.12);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
+}
+
+.nfl-btn-ghost {
+  background: transparent;
+  border-color: var(--bg-black-50);
+  color: var(--text-black-700);
+}
+
+.nfl-btn-ghost:hover:not(:disabled) {
+  border-color: var(--skin-color);
+  color: var(--skin-color);
+}
+
+/* ─── Status message ──────────────────────────────────────────────────────── */
+.nfl-status-msg {
+  padding: 0.65rem 1rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  margin-top: 0.5rem;
+  transition: all 0.3s ease;
+}
+
+.nfl-status-loading { color: var(--text-black-700); }
+.nfl-status-success {
+  background: rgba(46, 213, 115, 0.12);
+  color: #2ed573;
+  border: 1px solid rgba(46, 213, 115, 0.3);
+}
+.nfl-status-error {
+  background: rgba(255, 71, 87, 0.12);
+  color: #ff6b81;
+  border: 1px solid rgba(255, 71, 87, 0.3);
+}
+.nfl-status-info {
+  background: rgba(0, 191, 255, 0.1);
+  color: #00bfff;
+  border: 1px solid rgba(0, 191, 255, 0.25);
+}
+
+/* ─── Import guide ────────────────────────────────────────────────────────── */
+.nfl-import-guide {
+  background: var(--bg-black-100);
+  border: 1px solid var(--bg-black-50);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  margin-top: 1rem;
+  font-size: 0.88rem;
+}
+
+.nfl-import-guide p {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: var(--text-black-900);
+  font-size: 0.9rem !important;
+  padding-bottom: 0;
+}
+
+.nfl-import-guide ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.nfl-import-guide li {
+  color: var(--text-black-700);
+  line-height: 1.4;
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────────────── */
+@media (max-width: 600px) {
+  .nfl-team-card { width: 60px; }
+  .nfl-logo { width: 32px; height: 32px; }
+}


### PR DESCRIPTION
## Summary

### 🦅 Eagles Calendar — now fully working
The old implementation relied solely on a Google Apps Script email invite, which could fail silently due to CORS, expiry, or an outdated schedule. Two paths now exist:

**Primary (always works):** A "Download Eagles Schedule (.ics)" button fetches the live Eagles schedule directly from the ESPN public API and generates a valid `.ics` file in the browser. No email, no backend. The schedule is always current — if ESPN has it, the download reflects it. Includes a collapsible import guide for Apple Calendar, Google Calendar, and Outlook.

**Secondary (kept as-is):** The email invite form sends via Google Apps Script with improved error messaging that falls back gracefully and suggests the direct download.

---

### 🏈 NFL Team Calendar Picker (new section)
- All 32 teams displayed in division groups with ESPN logo images
- Multi-select: click any team to select; team's accent color highlights the card with a checkmark
- "Select All 32" and "Clear" buttons in the toolbar
- Live schedule fetch from the **ESPN public API** (no API key, no backend, always current)
- Shared games across multiple selected teams are **deduplicated**
- Generates and downloads a standard `.ics` file named after selected teams (e.g. `nfl-schedule-PHI-KC-2025.ics`)
- Status messages and import guide after download
- Works with: Apple Calendar (double-click), Google Calendar (Settings → Import), Outlook (File → Import/Export)

---

### 🥚 Easter Eggs
| Trigger | Effect |
|---|---|
| Open DevTools | ASCII "AK" art + contact details + Konami Code hint printed in console |
| Konami Code ↑↑↓↓←→←→BA | 120-dot confetti burst + "DEVELOPER MODE ACTIVATED" toast |
| Logo clicked 5× quickly | Animated "HIRE ME" overlay with bouncing rocket emoji + confetti |
| Type `hire` anywhere | Subtle green flash: "💼 Hiring? Let's connect!" |
| Idle for 45 seconds | Rotating cheeky messages (5 variants) |

---

### 📊 Visitor Tracking
- Per-device visit count and first-visit date stored in `localStorage`
- Global hit counter via [CountAPI](https://api.countapi.xyz) (free, no auth) with graceful silent fallback
- Subtle bottom-left badge with a pulsing green "live" dot; fades as you scroll down

---

## How the data stays current
Both the Eagles download and the NFL picker pull from `site.api.espn.com` at click-time. No schedule data is hardcoded. When ESPN updates their schedule (week-to-week, season-to-season), the downloads automatically reflect the latest data. Nothing to maintain.

## Test plan
- [ ] Click "Download Eagles Schedule (.ics)" → file downloads; import into a calendar app and verify Eagles games appear
- [ ] Email form still submits and shows success/error response
- [ ] Select 2–3 NFL teams → click "Download .ics" → file contains combined schedule with no duplicate games
- [ ] "Select All 32" selects every team card; "Clear" deselects all
- [ ] Open browser DevTools console → ASCII art and contact info visible
- [ ] Enter Konami Code (↑↑↓↓←→←→BA) → confetti + toast appear
- [ ] Click the "AK" logo 5 times rapidly → HIRE ME overlay appears, close works
- [ ] Type the word `hire` anywhere on page (not in an input) → green flash appears
- [ ] Leave page idle 45s → idle message toast appears
- [ ] Visitor badge visible bottom-left on load; fades after scrolling past 300px; shows visit number and global count

https://claude.ai/code/session_01ADNAYMar8TbZkUckDBmoPu

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADNAYMar8TbZkUckDBmoPu)_