### PR TITLE
Make the UI more fun and lively

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
       type="image/x-icon"
     />
 
+    <link rel="stylesheet" href="./styles/color-1.css" />
     <link rel="stylesheet" href="./styles/styles.css" />
 
     <link rel="stylesheet" href="./styles/style_switcher.css" />
@@ -70,6 +71,7 @@
     <link rel="stylesheet" href="./styles/cryforhelp.css" />
     <link rel="stylesheet" href="./styles/nfl-calendar.css" />
     <link rel="stylesheet" href="./styles/easter-eggs.css" />
+    <link rel="stylesheet" href="./styles/fun-ui.css" />
 
     <link
       rel="stylesheet"
@@ -137,16 +139,19 @@
         </div>
 
         <div class="asking_job">
-          <!-- <br /> -->
+          <div class="open-to-work-badge">
+            <span class="otw-dot"></span>
+            Open to Work
+          </div>
           <h1>Welp, I Need a Job 🧑‍💻</h1>
-          <p>Full Stack & DevCloudOps Engineer</p>
+          <div class="profession-badges">
+            <span class="prof-badge"><i class="fas fa-code"></i> Full Stack Dev</span>
+            <span class="prof-badge"><i class="fas fa-cloud"></i> DevOps &amp; Cloud</span>
+            <span class="prof-badge"><i class="fas fa-layer-group"></i> CI/CD Pipelines</span>
+          </div>
           <p>
-            <i
-              ><strong
-                >I <span>enjoy</span> building Web application products and
-                efficient CI/CD pipelines!</strong
-              ></i
-            >
+            <i><strong>I <span>enjoy</span> building Web application products and
+                efficient CI/CD pipelines!</strong></i>
           </p>
           <p id="years_experience"></p>
         </div>

--- a/index.html
+++ b/index.html
@@ -68,6 +68,8 @@
     <link rel="stylesheet" href="./styles/musicSection.css" />
     <link rel="stylesheet" href="./styles/projectStyles.css" />
     <link rel="stylesheet" href="./styles/cryforhelp.css" />
+    <link rel="stylesheet" href="./styles/nfl-calendar.css" />
+    <link rel="stylesheet" href="./styles/easter-eggs.css" />
 
     <link
       rel="stylesheet"
@@ -205,6 +207,27 @@
                 <p class="birds_accent">
                   <span class="birds_accent">GO BIRDS! 🦅</span>
                 </p>
+
+                <!-- Primary: direct ICS download powered by ESPN live data -->
+                <div class="eagles-direct-download">
+                  <p class="eagles-direct-label">📅 Add all games instantly — no email needed:</p>
+                  <button id="eagles-direct-ics" class="btn eagles-ics-btn">
+                    <i class="fas fa-download"></i> Download Eagles Schedule (.ics)
+                  </button>
+                  <p class="eagles-direct-note">Works with Apple Calendar, Google Calendar &amp; Outlook · Always up-to-date from ESPN</p>
+                  <div id="eagles-direct-status" class="eagles-direct-status"></div>
+                  <div id="eagles-import-guide" class="eagles-import-guide" hidden>
+                    <strong>How to import:</strong>
+                    <ul>
+                      <li>🍎 <b>Apple Calendar</b>: Double-click the downloaded file</li>
+                      <li>📅 <b>Google Calendar</b>: Settings → Import → Upload the file</li>
+                      <li>📧 <b>Outlook</b>: File → Open &amp; Export → Import/Export</li>
+                    </ul>
+                  </div>
+                </div>
+
+                <div class="eagles-divider"><span>or get calendar invites via email</span></div>
+
                 <form id="inviteForm" class="invite_form">
                   <div class="form-group" id="formGroup">
                     <div class="marquee-text">
@@ -231,6 +254,44 @@
                     <span id="responseText"></span>
                   </div>
                 </form>
+              </div>
+            </div>
+          </div>
+
+          <!-- NFL Team Calendar Picker -->
+          <div class="nfl-calendar-wrapper row">
+            <div class="padd_15 nfl-calendar-section" style="width:100%">
+              <h3 class="nfl-section-title">🏈 Add Any NFL Team to Your Calendar</h3>
+              <p class="nfl-section-sub">
+                Pick one or more teams — schedules are fetched live from ESPN and exported as a standard .ics file that works everywhere.
+              </p>
+
+              <div class="nfl-toolbar">
+                <button class="nfl-toolbar-btn" id="nfl-select-all-btn">Select All 32</button>
+                <button class="nfl-toolbar-btn" id="nfl-clear-btn">Clear</button>
+                <span class="nfl-selected-count" id="nfl-selected-count">No teams selected</span>
+              </div>
+
+              <div class="nfl-teams-grid" id="nfl-teams-grid"></div>
+
+              <div class="nfl-actions">
+                <button class="nfl-btn nfl-btn-primary" id="nfl-download-ics" disabled>
+                  <i class="fas fa-download"></i> Download .ics
+                </button>
+                <button class="nfl-btn nfl-btn-ghost" id="nfl-clear-btn-2">
+                  <i class="fas fa-times"></i> Clear
+                </button>
+              </div>
+
+              <div id="nfl-status"></div>
+
+              <div id="nfl-import-guide" class="nfl-import-guide" hidden>
+                <p>How to import into your calendar:</p>
+                <ul>
+                  <li>🍎 <strong>Apple Calendar</strong>: Double-click the .ics file</li>
+                  <li>📅 <strong>Google Calendar</strong>: Settings ⚙️ → Import → Upload file</li>
+                  <li>📧 <strong>Outlook</strong>: File → Open &amp; Export → Import/Export</li>
+                </ul>
               </div>
             </div>
           </div>
@@ -462,5 +523,8 @@
 
     <script src="./scripts/script.js"></script>
     <script src="./scripts/style-switcher.js"></script>
+    <script src="./scripts/nfl-calendar.js"></script>
+    <script src="./scripts/easter-eggs.js"></script>
+    <script src="./scripts/visitor-tracker.js"></script>
   </body>
 </html>

--- a/scripts/calendarInvite.js
+++ b/scripts/calendarInvite.js
@@ -1,63 +1,191 @@
-document.addEventListener('DOMContentLoaded', () => {
-    const form = document.getElementById("inviteForm");
-    const emailInput = document.getElementById("email");
-    const submitButton = document.getElementById("submitButton");
-    const formGroup = document.getElementById("formGroup");
+/**
+ * Eagles Calendar Invite
+ * Primary:   Download an ICS file built in real-time from ESPN's public API
+ * Secondary: Email invite via Google Apps Script (requires user email)
+ */
+document.addEventListener("DOMContentLoaded", () => {
+  // ── Email-based invite (secondary path) ──────────────────────────────────
+  const form              = document.getElementById("inviteForm");
+  const emailInput        = document.getElementById("email");
+  const submitButton      = document.getElementById("submitButton");
+  const formGroup         = document.getElementById("formGroup");
+  const responseMessageDiv = document.getElementById("responseMessage");
+  const responseIcon      = document.getElementById("responseIcon");
+  const responseText      = document.getElementById("responseText");
 
-    const responseMessageDiv = document.getElementById("responseMessage");
-    const responseIcon = document.getElementById("responseIcon");
-    const responseText = document.getElementById("responseText");
+  const SCRIPT_URL =
+    "https://script.google.com/macros/s/AKfycbyYmu3bPV2n79YBC1uSPphErMxAGGrAmwLbR-QzqLtu71LrxemqDldZaj0K-w-FVciFVg/exec";
 
-    const SCRIPT_URL = "https://script.google.com/macros/s/AKfycbyYmu3bPV2n79YBC1uSPphErMxAGGrAmwLbR-QzqLtu71LrxemqDldZaj0K-w-FVciFVg/exec";
+  if (form) {
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
 
-    form.addEventListener('submit', (e) => {
-        e.preventDefault();
+      submitButton.disabled = true;
+      submitButton.classList.add("loading");
+      formGroup.classList.add("loading");
+      emailInput.disabled = true;
+      responseMessageDiv.classList.remove("visible", "success", "error");
 
-
-        submitButton.disabled = true;
-        submitButton.classList.add('loading');
-        formGroup.classList.add('loading');
-
-        emailInput.disabled = true;
-
-        responseMessageDiv.classList.remove('visible', 'success', 'error');
-
-        // 2. Make the fetch request to the Google Apps Script
-        fetch(SCRIPT_URL, {
-            method: 'POST',
-            body: new URLSearchParams({
-                email: emailInput.value
-            })
+      fetch(SCRIPT_URL, {
+        method: "POST",
+        redirect: "follow",
+        body: new URLSearchParams({ email: emailInput.value }),
+      })
+        .then((r) => {
+          if (!r.ok) throw new Error(`HTTP ${r.status}`);
+          return r.json();
         })
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error(`Network response was not ok: ${response.statusText}`);
-                }
-                return response.json();
-            })
-            .then(data => {
-                responseText.textContent = data.message;
-                if (data.status === 'success') {
-                    responseMessageDiv.classList.add('success');
-                    responseIcon.className = 'fa-solid fa-circle-check';
-                    form.reset();
-                } else {
-                    responseMessageDiv.classList.add('error');
-                    responseIcon.className = 'fa-solid fa-circle-xmark';
-                }
-            })
-            .catch(error => {
-                console.error("Fetch Error:", error);
-                responseMessageDiv.classList.add('error');
-                responseIcon.className = 'fa-solid fa-triangle-exclamation';
-                responseText.textContent = 'An unexpected error occurred. Please try again.';
-            })
-            .finally(() => {
-                submitButton.disabled = false;
-                submitButton.classList.remove('loading');
-                formGroup.classList.remove('loading');
-                emailInput.disabled = false
-                responseMessageDiv.classList.add('visible');
-            });
+        .then((data) => {
+          responseText.textContent = data.message;
+          responseIcon.className =
+            data.status === "success"
+              ? "fa-solid fa-circle-check"
+              : "fa-solid fa-circle-xmark";
+          responseMessageDiv.classList.add(
+            data.status === "success" ? "success" : "error"
+          );
+          if (data.status === "success") form.reset();
+        })
+        .catch(() => {
+          responseMessageDiv.classList.add("error");
+          responseIcon.className = "fa-solid fa-triangle-exclamation";
+          responseText.textContent =
+            "Couldn't reach the server. Try the direct download below instead!";
+        })
+        .finally(() => {
+          submitButton.disabled = false;
+          submitButton.classList.remove("loading");
+          formGroup.classList.remove("loading");
+          emailInput.disabled = false;
+          responseMessageDiv.classList.add("visible");
+        });
     });
+  }
+
+  // ── Direct ICS download (primary path) ───────────────────────────────────
+  const EAGLES_TEAM_ID = "21"; // ESPN team ID for Philadelphia Eagles
+
+  const directBtn   = document.getElementById("eagles-direct-ics");
+  const directStatus = document.getElementById("eagles-direct-status");
+
+  if (!directBtn) return;
+
+  directBtn.addEventListener("click", async () => {
+    directBtn.disabled = true;
+    directBtn.innerHTML = `<i class="fas fa-spinner fa-spin"></i> Fetching schedule…`;
+    setDirectStatus("Fetching live schedule from ESPN…", "loading");
+
+    try {
+      const data  = await fetchEaglesSchedule();
+      const games = parseEaglesGames(data);
+
+      if (games.length === 0) {
+        setDirectStatus("No upcoming games found. Check back later!", "error");
+        return;
+      }
+
+      const ics = buildICS(games);
+      triggerDownload(ics, "eagles-2025-schedule.ics");
+      setDirectStatus(
+        `✅ Downloaded ${games.length} Eagles games! Import the file into your calendar app.`,
+        "success"
+      );
+
+      // Show import guide
+      const guide = document.getElementById("eagles-import-guide");
+      if (guide) guide.hidden = false;
+    } catch (err) {
+      console.error("Eagles ICS error:", err);
+      setDirectStatus(
+        "❌ Could not reach ESPN. Check your connection and try again.",
+        "error"
+      );
+    } finally {
+      directBtn.disabled = false;
+      directBtn.innerHTML = `<i class="fas fa-download"></i> Download Eagles Schedule (.ics)`;
+    }
+  });
+
+  function setDirectStatus(msg, type) {
+    if (!directStatus) return;
+    directStatus.textContent = msg;
+    directStatus.className = `eagles-direct-status status-${type}`;
+  }
+
+  // ── ESPN helpers ──────────────────────────────────────────────────────────
+  async function fetchEaglesSchedule() {
+    const url = `https://site.api.espn.com/apis/site/v2/sports/football/nfl/teams/${EAGLES_TEAM_ID}/schedule`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`ESPN API ${res.status}`);
+    return res.json();
+  }
+
+  function parseEaglesGames(data) {
+    return (data.events || [])
+      .filter((e) => e.competitions?.[0])
+      .map((e) => {
+        const comp    = e.competitions[0];
+        const home    = comp.competitors?.find((c) => c.homeAway === "home");
+        const away    = comp.competitors?.find((c) => c.homeAway === "away");
+        const venue   = comp.venue || {};
+        const homeAbbr = home?.team?.abbreviation ?? "HOME";
+        const awayAbbr = away?.team?.abbreviation ?? "AWAY";
+        const isHomeGame = home?.team?.id === EAGLES_TEAM_ID;
+        return {
+          uid:      e.id,
+          start:    new Date(e.date),
+          summary:  `🦅 Eagles: ${awayAbbr} @ ${homeAbbr}${isHomeGame ? " 🏟" : ""}`,
+          description: `Philadelphia Eagles — ${e.season?.year ?? "2025"} NFL Season\n${e.name ?? ""}`,
+          location: [venue.fullName, venue.address?.city, venue.address?.state]
+            .filter(Boolean)
+            .join(", "),
+        };
+      });
+  }
+
+  // ── ICS builder ───────────────────────────────────────────────────────────
+  function toUTC(date) {
+    return date.toISOString().replace(/[-:.]/g, "").slice(0, 15) + "Z";
+  }
+
+  function buildICS(games) {
+    const lines = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//Eagles 2025 Schedule//AK Portfolio//EN",
+      "CALSCALE:GREGORIAN",
+      "METHOD:PUBLISH",
+      "X-WR-CALNAME:🦅 Eagles 2025 Season",
+      "X-WR-TIMEZONE:America/New_York",
+    ];
+
+    games.forEach((g) => {
+      const end = new Date(g.start.getTime() + 3 * 60 * 60 * 1000);
+      lines.push(
+        "BEGIN:VEVENT",
+        `UID:${g.uid}@eagles-ak-portfolio`,
+        `DTSTART:${toUTC(g.start)}`,
+        `DTEND:${toUTC(end)}`,
+        `SUMMARY:${g.summary}`,
+        `DESCRIPTION:${g.description.replace(/\n/g, "\\n")}`,
+        `LOCATION:${g.location}`,
+        "END:VEVENT"
+      );
+    });
+
+    lines.push("END:VCALENDAR");
+    return lines.join("\r\n");
+  }
+
+  function triggerDownload(content, filename) {
+    const blob = new Blob([content], { type: "text/calendar;charset=utf-8" });
+    const url  = URL.createObjectURL(blob);
+    const a    = Object.assign(document.createElement("a"), {
+      href: url, download: filename,
+    });
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
 });

--- a/scripts/easter-eggs.js
+++ b/scripts/easter-eggs.js
@@ -1,0 +1,234 @@
+/**
+ * Easter Eggs 🥚
+ * 1. Console art on load
+ * 2. Konami Code → confetti party
+ * 3. Logo clicked 5× → "HIRE ME" overlay
+ * 4. Idle 45s → cheeky message
+ * 5. Secret word "hire" typed anywhere → flash animation
+ */
+
+// ─── 1. Console art ───────────────────────────────────────────────────────────
+(function printConsoleArt() {
+  const gold  = "color:#dfa70a;font-weight:bold;";
+  const white = "color:#e9e9e9;font-size:13px;";
+  const cyan  = "color:#00bfff;font-size:13px;";
+  const green = "color:#33ff99;font-size:13px;font-weight:bold;";
+
+  console.log(
+    "%c" +
+    "    _    _  __\n" +
+    "   / \\  | |/ /\n" +
+    "  / _ \\ | ' / \n" +
+    " / ___ \\| . \\ \n" +
+    "/_/   \\_\\_|\\_\\\n",
+    "color:#dfa70a;font-family:monospace;font-size:16px;font-weight:bold;"
+  );
+  console.log("%c👀 Oh hey, you found the DevTools — respect.", white);
+  console.log("%c🚀 Built by Anil Kumar — Full Stack & DevOps Engineer", green);
+  console.log("%c📧 karapaanilkumar@gmail.com", cyan);
+  console.log(
+    "%c🔗 linkedin.com/in/anil-kumar-karapa/",
+    cyan
+  );
+  console.log(
+    "%c💡 Pro tip: try the Konami code on this page ↑↑↓↓←→←→BA",
+    gold
+  );
+})();
+
+// ─── 2. Konami Code ───────────────────────────────────────────────────────────
+(function konamiCode() {
+  const SEQUENCE = [
+    "ArrowUp","ArrowUp","ArrowDown","ArrowDown",
+    "ArrowLeft","ArrowRight","ArrowLeft","ArrowRight",
+    "b","a",
+  ];
+  let idx = 0;
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === SEQUENCE[idx]) {
+      idx++;
+      if (idx === SEQUENCE.length) {
+        idx = 0;
+        triggerPartyMode();
+      }
+    } else {
+      idx = e.key === SEQUENCE[0] ? 1 : 0;
+    }
+  });
+
+  function triggerPartyMode() {
+    // Toast
+    const toast = document.createElement("div");
+    toast.className = "ee-toast";
+    toast.innerHTML =
+      "<span>🎉 DEVELOPER MODE ACTIVATED 🎉</span><br><small>Konami code unlocked!</small>";
+    document.body.appendChild(toast);
+    setTimeout(() => toast.classList.add("ee-toast-show"), 10);
+    setTimeout(() => {
+      toast.classList.remove("ee-toast-show");
+      setTimeout(() => toast.remove(), 400);
+    }, 3000);
+
+    // Big confetti burst
+    burstConfetti(120);
+  }
+})();
+
+// ─── 3. Logo 5× click ─────────────────────────────────────────────────────────
+(function logoClickEasterEgg() {
+  const logo = document.querySelector(".aside .logo a");
+  if (!logo) return;
+
+  let clicks = 0;
+  let timer;
+
+  logo.addEventListener("click", (e) => {
+    e.preventDefault();
+    clicks++;
+    clearTimeout(timer);
+    timer = setTimeout(() => (clicks = 0), 1200);
+
+    if (clicks >= 5) {
+      clicks = 0;
+      showHireMeOverlay();
+    }
+  });
+
+  function showHireMeOverlay() {
+    if (document.getElementById("hire-me-overlay")) return;
+
+    const overlay = document.createElement("div");
+    overlay.id = "hire-me-overlay";
+    overlay.innerHTML = `
+      <div class="hire-me-box">
+        <div class="hire-me-emoji">🚀</div>
+        <h2 class="hire-me-title">HIRE ME!</h2>
+        <p class="hire-me-subtitle">Seriously though 🥺</p>
+        <p class="hire-me-sub2">Full Stack · DevOps · Cloud · Enthusiastic Human</p>
+        <a href="mailto:karapaanilkumar@gmail.com" class="hire-me-btn">
+          📧 Let's Talk
+        </a>
+        <button class="hire-me-close" id="hire-me-close">Maybe later</button>
+      </div>
+    `;
+    document.body.appendChild(overlay);
+    setTimeout(() => overlay.classList.add("hire-me-visible"), 10);
+    burstConfetti(80);
+
+    document.getElementById("hire-me-close").addEventListener("click", () => {
+      overlay.classList.remove("hire-me-visible");
+      setTimeout(() => overlay.remove(), 400);
+    });
+    overlay.addEventListener("click", (e) => {
+      if (e.target === overlay) {
+        overlay.classList.remove("hire-me-visible");
+        setTimeout(() => overlay.remove(), 400);
+      }
+    });
+  }
+})();
+
+// ─── 4. Idle message ──────────────────────────────────────────────────────────
+(function idleMessage() {
+  const IDLE_MS = 45000;
+  const MESSAGES = [
+    "👀 Still here? I like your dedication.",
+    "☕ Go grab a coffee — I'll still be here.",
+    "🤔 Thinking about reaching out?",
+    "🎯 Psst… the email link is right up top.",
+    "💡 Fun fact: This site runs on 0 frameworks. Just vibes.",
+  ];
+  let idleTimer;
+  let toast;
+  let msgIdx = 0;
+
+  function resetIdle() {
+    clearTimeout(idleTimer);
+    if (toast) {
+      toast.classList.remove("ee-toast-show");
+    }
+    idleTimer = setTimeout(showIdleMsg, IDLE_MS);
+  }
+
+  function showIdleMsg() {
+    if (document.hidden) return;
+    if (toast) toast.remove();
+    toast = document.createElement("div");
+    toast.className = "ee-toast ee-idle-toast";
+    toast.textContent = MESSAGES[msgIdx % MESSAGES.length];
+    msgIdx++;
+    document.body.appendChild(toast);
+    setTimeout(() => toast.classList.add("ee-toast-show"), 10);
+    setTimeout(() => {
+      toast.classList.remove("ee-toast-show");
+      setTimeout(() => { if (toast) toast.remove(); toast = null; }, 400);
+    }, 4500);
+  }
+
+  ["mousemove","keydown","scroll","click","touchstart"].forEach((ev) =>
+    document.addEventListener(ev, resetIdle, { passive: true })
+  );
+  resetIdle();
+})();
+
+// ─── 5. Secret word "hire" typed anywhere ─────────────────────────────────────
+(function secretWordEgg() {
+  const TARGET = "hire";
+  let buf = "";
+
+  document.addEventListener("keydown", (e) => {
+    if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") return;
+    buf = (buf + e.key).slice(-TARGET.length).toLowerCase();
+    if (buf === TARGET) {
+      buf = "";
+      flashHireGlow();
+    }
+  });
+
+  function flashHireGlow() {
+    const flash = document.createElement("div");
+    flash.className = "ee-hire-flash";
+    flash.textContent = "💼 Hiring? Let's connect!";
+    document.body.appendChild(flash);
+    setTimeout(() => flash.classList.add("ee-hire-flash-show"), 10);
+    setTimeout(() => {
+      flash.classList.remove("ee-hire-flash-show");
+      setTimeout(() => flash.remove(), 600);
+    }, 2200);
+  }
+})();
+
+// ─── Shared confetti helper ────────────────────────────────────────────────────
+function burstConfetti(count = 60) {
+  const colors = [
+    "#dfa70a","#ff6b6b","#4ecdc4","#45b7d1","#f9ca24",
+    "#6c5ce7","#fd79a8","#00b894","#e17055","#74b9ff",
+  ];
+  const cx = window.innerWidth / 2;
+  const cy = window.innerHeight / 2;
+
+  for (let i = 0; i < count; i++) {
+    const dot = document.createElement("div");
+    dot.className = "ee-confetti-dot";
+    const color = colors[Math.floor(Math.random() * colors.length)];
+    const angle = Math.random() * Math.PI * 2;
+    const dist  = 150 + Math.random() * 250;
+    const tx    = Math.cos(angle) * dist;
+    const ty    = Math.sin(angle) * dist;
+    const size  = 6 + Math.random() * 8;
+
+    Object.assign(dot.style, {
+      left: cx + "px",
+      top:  cy + "px",
+      width: size + "px",
+      height: size + "px",
+      background: color,
+      borderRadius: Math.random() > 0.5 ? "50%" : "2px",
+      "--tx": tx + "px",
+      "--ty": ty + "px",
+    });
+    document.body.appendChild(dot);
+    setTimeout(() => dot.remove(), 1400);
+  }
+}

--- a/scripts/nfl-calendar.js
+++ b/scripts/nfl-calendar.js
@@ -1,0 +1,283 @@
+/**
+ * NFL Team Calendar Picker
+ * Fetches real-time schedules from the ESPN public API (no key needed)
+ * and generates ICS files for any selected teams.
+ */
+document.addEventListener("DOMContentLoaded", () => {
+  // ─── Team roster with ESPN IDs ────────────────────────────────────────────
+  const NFL_TEAMS = [
+    { id: "22", name: "Arizona Cardinals",    abbr: "ARI", color: "#97233F", division: "NFC West"  },
+    { id: "1",  name: "Atlanta Falcons",      abbr: "ATL", color: "#A71930", division: "NFC South" },
+    { id: "33", name: "Baltimore Ravens",     abbr: "BAL", color: "#241773", division: "AFC North" },
+    { id: "2",  name: "Buffalo Bills",        abbr: "BUF", color: "#00338D", division: "AFC East"  },
+    { id: "29", name: "Carolina Panthers",    abbr: "CAR", color: "#0085CA", division: "NFC South" },
+    { id: "3",  name: "Chicago Bears",        abbr: "CHI", color: "#C83803", division: "NFC North" },
+    { id: "4",  name: "Cincinnati Bengals",   abbr: "CIN", color: "#FB4F14", division: "AFC North" },
+    { id: "5",  name: "Cleveland Browns",     abbr: "CLE", color: "#FF3C00", division: "AFC North" },
+    { id: "6",  name: "Dallas Cowboys",       abbr: "DAL", color: "#003594", division: "NFC East"  },
+    { id: "7",  name: "Denver Broncos",       abbr: "DEN", color: "#FB4F14", division: "AFC West"  },
+    { id: "8",  name: "Detroit Lions",        abbr: "DET", color: "#0076B6", division: "NFC North" },
+    { id: "9",  name: "Green Bay Packers",    abbr: "GB",  color: "#203731", division: "NFC North" },
+    { id: "34", name: "Houston Texans",       abbr: "HOU", color: "#03202F", division: "AFC South" },
+    { id: "11", name: "Indianapolis Colts",   abbr: "IND", color: "#002C5F", division: "AFC South" },
+    { id: "30", name: "Jacksonville Jaguars", abbr: "JAX", color: "#006778", division: "AFC South" },
+    { id: "12", name: "Kansas City Chiefs",   abbr: "KC",  color: "#E31837", division: "AFC West"  },
+    { id: "13", name: "Las Vegas Raiders",    abbr: "LV",  color: "#A5ACAF", division: "AFC West"  },
+    { id: "24", name: "Los Angeles Chargers", abbr: "LAC", color: "#0080C6", division: "AFC West"  },
+    { id: "14", name: "Los Angeles Rams",     abbr: "LAR", color: "#003594", division: "NFC West"  },
+    { id: "15", name: "Miami Dolphins",       abbr: "MIA", color: "#008E97", division: "AFC East"  },
+    { id: "16", name: "Minnesota Vikings",    abbr: "MIN", color: "#4F2683", division: "NFC North" },
+    { id: "17", name: "New England Patriots", abbr: "NE",  color: "#002244", division: "AFC East"  },
+    { id: "18", name: "New Orleans Saints",   abbr: "NO",  color: "#D3BC8D", division: "NFC South" },
+    { id: "19", name: "New York Giants",      abbr: "NYG", color: "#0B2265", division: "NFC East"  },
+    { id: "20", name: "New York Jets",        abbr: "NYJ", color: "#125740", division: "AFC East"  },
+    { id: "21", name: "Philadelphia Eagles",  abbr: "PHI", color: "#004C54", division: "NFC East"  },
+    { id: "23", name: "Pittsburgh Steelers",  abbr: "PIT", color: "#FFB612", division: "AFC North" },
+    { id: "25", name: "San Francisco 49ers",  abbr: "SF",  color: "#AA0000", division: "NFC West"  },
+    { id: "26", name: "Seattle Seahawks",     abbr: "SEA", color: "#002244", division: "NFC West"  },
+    { id: "27", name: "Tampa Bay Buccaneers", abbr: "TB",  color: "#D50A0A", division: "NFC South" },
+    { id: "10", name: "Tennessee Titans",     abbr: "TEN", color: "#4B92DB", division: "AFC South" },
+    { id: "28", name: "Washington Commanders",abbr: "WAS", color: "#5A1414", division: "NFC East"  },
+  ];
+
+  const DIVISIONS = [
+    "AFC East","AFC North","AFC South","AFC West",
+    "NFC East","NFC North","NFC South","NFC West",
+  ];
+
+  // ─── DOM refs ─────────────────────────────────────────────────────────────
+  const grid          = document.getElementById("nfl-teams-grid");
+  const downloadBtn   = document.getElementById("nfl-download-ics");
+  const clearBtn      = document.getElementById("nfl-clear-btn");
+  const selectAllBtn  = document.getElementById("nfl-select-all-btn");
+  const statusEl      = document.getElementById("nfl-status");
+  const countLabel    = document.getElementById("nfl-selected-count");
+  const importGuide   = document.getElementById("nfl-import-guide");
+
+  if (!grid) return;
+
+  // ─── State ────────────────────────────────────────────────────────────────
+  const selected = new Set();
+
+  // ─── Render team grid grouped by division ─────────────────────────────────
+  DIVISIONS.forEach((division) => {
+    const teamsInDiv = NFL_TEAMS.filter((t) => t.division === division);
+
+    const divWrapper = document.createElement("div");
+    divWrapper.className = "nfl-division-group";
+
+    const divTitle = document.createElement("h4");
+    divTitle.className = "nfl-division-title";
+    divTitle.textContent = division;
+    divWrapper.appendChild(divTitle);
+
+    const teamRow = document.createElement("div");
+    teamRow.className = "nfl-division-teams";
+
+    teamsInDiv.forEach((team) => {
+      const card = document.createElement("button");
+      card.className = "nfl-team-card";
+      card.dataset.id = team.id;
+      card.style.setProperty("--tc", team.color);
+      card.title = team.name;
+      card.innerHTML = `
+        <span class="nfl-check-icon"><i class="fas fa-check"></i></span>
+        <img
+          src="https://a.espncdn.com/i/teamlogos/nfl/500/${team.abbr.toLowerCase()}.png"
+          alt="${team.name} logo"
+          class="nfl-logo"
+          loading="lazy"
+          onerror="this.src=''"
+        />
+        <span class="nfl-abbr">${team.abbr}</span>
+      `;
+      card.addEventListener("click", () => toggleTeam(team, card));
+      teamRow.appendChild(card);
+    });
+
+    divWrapper.appendChild(teamRow);
+    grid.appendChild(divWrapper);
+  });
+
+  // ─── Toggle selection ─────────────────────────────────────────────────────
+  function toggleTeam(team, card) {
+    if (selected.has(team.id)) {
+      selected.delete(team.id);
+      card.classList.remove("nfl-selected");
+    } else {
+      selected.add(team.id);
+      card.classList.add("nfl-selected");
+    }
+    refreshUI();
+  }
+
+  function refreshUI() {
+    const n = selected.size;
+    countLabel.textContent =
+      n === 0 ? "No teams selected" : `${n} team${n !== 1 ? "s" : ""} selected`;
+    downloadBtn.disabled = n === 0;
+    if (statusEl) statusEl.textContent = "";
+    if (importGuide) importGuide.hidden = true;
+  }
+
+  // ─── Select all / clear ───────────────────────────────────────────────────
+  selectAllBtn?.addEventListener("click", () => {
+    NFL_TEAMS.forEach((team) => {
+      selected.add(team.id);
+      grid
+        .querySelector(`[data-id="${team.id}"]`)
+        ?.classList.add("nfl-selected");
+    });
+    refreshUI();
+  });
+
+  function clearAll() {
+    selected.clear();
+    grid
+      .querySelectorAll(".nfl-team-card.nfl-selected")
+      .forEach((c) => c.classList.remove("nfl-selected"));
+    refreshUI();
+  }
+
+  clearBtn?.addEventListener("click", clearAll);
+  document.getElementById("nfl-clear-btn-2")?.addEventListener("click", clearAll);
+
+  // ─── ESPN API helpers ─────────────────────────────────────────────────────
+  async function fetchTeamSchedule(teamId) {
+    const url = `https://site.api.espn.com/apis/site/v2/sports/football/nfl/teams/${teamId}/schedule`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`ESPN API ${res.status} for team ${teamId}`);
+    return res.json();
+  }
+
+  function parseGames(data, teamName) {
+    return (data.events || [])
+      .filter((e) => e.competitions?.[0])
+      .map((e) => {
+        const comp = e.competitions[0];
+        const home = comp.competitors?.find((c) => c.homeAway === "home");
+        const away = comp.competitors?.find((c) => c.homeAway === "away");
+        const venue = comp.venue || {};
+        const homeAbbr = home?.team?.abbreviation ?? "HOME";
+        const awayAbbr = away?.team?.abbreviation ?? "AWAY";
+        return {
+          uid: e.id,
+          start: new Date(e.date),
+          summary: `🏈 ${awayAbbr} @ ${homeAbbr}`,
+          description: `NFL ${e.season?.year ?? ""} — ${teamName}\n${e.name ?? ""}`,
+          location: [venue.fullName, venue.address?.city, venue.address?.state]
+            .filter(Boolean)
+            .join(", "),
+        };
+      });
+  }
+
+  // ─── ICS builder ──────────────────────────────────────────────────────────
+  function toUTC(date) {
+    return date.toISOString().replace(/[-:.]/g, "").slice(0, 15) + "Z";
+  }
+
+  function buildICS(games) {
+    const lines = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//NFL Schedule 2025//AK Portfolio//EN",
+      "CALSCALE:GREGORIAN",
+      "METHOD:PUBLISH",
+      "X-WR-CALNAME:NFL Schedule 2025",
+      "X-WR-TIMEZONE:America/New_York",
+    ];
+
+    games.forEach((g) => {
+      const end = new Date(g.start.getTime() + 3 * 60 * 60 * 1000);
+      lines.push(
+        "BEGIN:VEVENT",
+        `UID:${g.uid}@nfl-ak-portfolio`,
+        `DTSTART:${toUTC(g.start)}`,
+        `DTEND:${toUTC(end)}`,
+        `SUMMARY:${g.summary}`,
+        `DESCRIPTION:${g.description.replace(/\n/g, "\\n")}`,
+        `LOCATION:${g.location}`,
+        "END:VEVENT"
+      );
+    });
+
+    lines.push("END:VCALENDAR");
+    return lines.join("\r\n");
+  }
+
+  function triggerDownload(content, filename) {
+    const blob = new Blob([content], { type: "text/calendar;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = Object.assign(document.createElement("a"), {
+      href: url,
+      download: filename,
+    });
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+
+  function setStatus(msg, type = "info") {
+    if (!statusEl) return;
+    statusEl.textContent = msg;
+    statusEl.className = `nfl-status-msg nfl-status-${type}`;
+  }
+
+  // ─── Download handler ─────────────────────────────────────────────────────
+  downloadBtn?.addEventListener("click", async () => {
+    const teamIds = [...selected];
+    downloadBtn.disabled = true;
+    downloadBtn.innerHTML = `<i class="fas fa-spinner fa-spin"></i> Fetching from ESPN…`;
+    setStatus("⏳ Fetching live schedule data from ESPN…", "loading");
+
+    try {
+      const results = await Promise.all(
+        teamIds.map((id) => {
+          const team = NFL_TEAMS.find((t) => t.id === id);
+          return fetchTeamSchedule(id).then((data) =>
+            parseGames(data, team.name)
+          );
+        })
+      );
+
+      // Deduplicate by uid (shared games appear in both teams' schedules)
+      const seen = new Set();
+      const unique = results
+        .flat()
+        .filter((g) => {
+          if (seen.has(g.uid)) return false;
+          seen.add(g.uid);
+          return true;
+        })
+        .sort((a, b) => a.start - b.start);
+
+      if (unique.length === 0) {
+        setStatus("No upcoming games found for the selected teams.", "error");
+        return;
+      }
+
+      const ics = buildICS(unique);
+      const teamNames = teamIds
+        .map((id) => NFL_TEAMS.find((t) => t.id === id)?.abbr)
+        .join("-");
+      triggerDownload(ics, `nfl-schedule-${teamNames}-2025.ics`);
+
+      setStatus(
+        `✅ Downloaded ${unique.length} game${unique.length !== 1 ? "s" : ""} for ${teamIds.length} team${teamIds.length !== 1 ? "s" : ""}!`,
+        "success"
+      );
+      if (importGuide) importGuide.hidden = false;
+    } catch (err) {
+      console.error("NFL schedule fetch error:", err);
+      setStatus("❌ Could not fetch schedules from ESPN. Try again shortly.", "error");
+    } finally {
+      downloadBtn.disabled = false;
+      downloadBtn.innerHTML = `<i class="fas fa-download"></i> Download .ics`;
+      downloadBtn.disabled = selected.size === 0;
+    }
+  });
+
+  refreshUI();
+});

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -40,6 +40,98 @@ document.addEventListener("DOMContentLoaded", function () {
   window.addEventListener("scroll", onScroll, { passive: true });
 });
 
+// ─── 3D tilt on project cards ──────────────────────────────────────────────
+// Runs after projects are injected into the DOM via MutationObserver
+(function initCardTilt() {
+  const MAX_TILT = 7;
+
+  function applyTilt(card) {
+    card.addEventListener("mousemove", (e) => {
+      const r   = card.getBoundingClientRect();
+      const x   = e.clientX - r.left;
+      const y   = e.clientY - r.top;
+      const rx  = ((y / r.height) - 0.5) * -MAX_TILT * 2;
+      const ry  = ((x / r.width)  - 0.5) *  MAX_TILT * 2;
+      card.style.transform = `translateY(-10px) perspective(900px) rotateX(${rx}deg) rotateY(${ry}deg)`;
+    });
+    card.addEventListener("mouseleave", () => {
+      card.style.transform = "";
+    });
+  }
+
+  // Apply to existing cards and any added later
+  function attachAll() {
+    document.querySelectorAll(".project-card:not([data-tilt])").forEach((c) => {
+      c.dataset.tilt = "1";
+      applyTilt(c);
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    attachAll();
+    const grid = document.getElementById("projects-grid");
+    if (grid) {
+      new MutationObserver(attachAll).observe(grid, { childList: true });
+    }
+  });
+})();
+
+// ─── IntersectionObserver scroll-reveal ────────────────────────────────────
+document.addEventListener("DOMContentLoaded", () => {
+  const revealEls = document.querySelectorAll(
+    ".section, .skill-bookshelf-section, .about_content, .crl_card, .nfl-calendar-section"
+  );
+  if (!("IntersectionObserver" in window)) {
+    revealEls.forEach((el) => el.classList.add("is-visible"));
+    return;
+  }
+  const io = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((en) => {
+        if (en.isIntersecting) {
+          en.target.classList.add("is-visible");
+          io.unobserve(en.target);
+        }
+      });
+    },
+    { threshold: 0.08 }
+  );
+  revealEls.forEach((el) => {
+    el.classList.add("reveal");
+    io.observe(el);
+  });
+});
+
+// ─── Count-up animation for years of experience ────────────────────────────
+document.addEventListener("DOMContentLoaded", () => {
+  const el = document.getElementById("years_experience");
+  if (!el) return;
+
+  // Wait until experienceCal.js has set the text
+  const waitForText = setInterval(() => {
+    const raw = el.textContent;
+    const match = raw.match(/([\d.]+)/);
+    if (!match) return;
+    clearInterval(waitForText);
+
+    const target = parseFloat(match[1]);
+    const prefix = raw.slice(0, raw.indexOf(match[1]));
+    const suffix = raw.slice(raw.indexOf(match[1]) + match[1].length);
+    let start = null;
+    const DURATION = 1400;
+
+    function step(ts) {
+      if (!start) start = ts;
+      const progress = Math.min((ts - start) / DURATION, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      el.textContent = prefix + (eased * target).toFixed(1) + suffix;
+      if (progress < 1) requestAnimationFrame(step);
+    }
+    requestAnimationFrame(step);
+  }, 100);
+});
+
+// ─── Typed.js ───────────────────────────────────────────────────────────────
 document.addEventListener("DOMContentLoaded", function () {
   const typingElement = document.querySelector(".typing");
 

--- a/scripts/skills.js
+++ b/scripts/skills.js
@@ -132,6 +132,10 @@ document.addEventListener("DOMContentLoaded", () => {
       book.style.animationDelay = `${totalBookIndex * 0.05}s`;
 
       book.addEventListener("mouseover", () => {
+        // flash the panel so the new text feels alive
+        descriptionPanel.classList.remove("panel-pop");
+        void descriptionPanel.offsetWidth; // reflow to restart animation
+        descriptionPanel.classList.add("panel-pop");
         descriptionPanel.innerHTML = `<span class="skill-name">${skill.name}</span>${skill.desc}`;
       });
 

--- a/scripts/updatedProjects.js
+++ b/scripts/updatedProjects.js
@@ -88,11 +88,15 @@ document.addEventListener("DOMContentLoaded", () => {
         .map((tag) => `<span class="card-tag">${tag}</span>`)
         .join("");
 
+      const isPinned = project.tags.includes("Pinned");
+      if (isPinned) card.classList.add("is-pinned");
+
       const quickLookBtn = project.links.live
-        ? `<button class="card-btn btn-primary btn-quick-look" data-url="${project.links.live}" data-title="${project.title}">Quick Look</button>`
+        ? `<button class="card-btn btn-primary btn-quick-look" data-url="${project.links.live}" data-title="${project.title}"><i class="fas fa-eye" style="margin-right:0.35rem;font-size:0.85em;"></i>Quick Look</button>`
         : "";
 
       card.innerHTML = `
+        ${isPinned ? '<span class="card-pinned-ribbon" title="Featured project">📌</span>' : ""}
         <div class="card-image-container">
           <img src="${project.image}" alt="${project.title} Preview" loading="lazy">
         </div>
@@ -103,7 +107,7 @@ document.addEventListener("DOMContentLoaded", () => {
             ${tagsHtml}
           </div>
           <div class="card-links">
-            <a href="${project.links.github}" class="card-btn btn-secondary" target="_blank" rel="noopener noreferrer">View Code</a>
+            <a href="${project.links.github}" class="card-btn btn-secondary" target="_blank" rel="noopener noreferrer"><i class="fab fa-github" style="margin-right:0.35rem;"></i>View Code</a>
             ${quickLookBtn}
           </div>
         </div>

--- a/scripts/visitor-tracker.js
+++ b/scripts/visitor-tracker.js
@@ -1,0 +1,83 @@
+/**
+ * Visitor Tracker
+ * - Tracks per-device visit count & first-visit date via localStorage
+ * - Attempts a global hit count via CountAPI (free, no auth)
+ * - Renders a subtle badge in the footer area
+ */
+(function initVisitorTracker() {
+  // ── Per-device stats ──────────────────────────────────────────────────────
+  const VISIT_KEY       = "ak_portfolio_visits";
+  const FIRST_VISIT_KEY = "ak_portfolio_first_visit";
+
+  const now       = new Date();
+  const firstVisit = localStorage.getItem(FIRST_VISIT_KEY) || now.toISOString();
+  const visits     = parseInt(localStorage.getItem(VISIT_KEY) || "0", 10) + 1;
+
+  localStorage.setItem(VISIT_KEY, visits);
+  if (!localStorage.getItem(FIRST_VISIT_KEY)) {
+    localStorage.setItem(FIRST_VISIT_KEY, firstVisit);
+  }
+
+  const firstDate = new Date(firstVisit);
+  const firstStr  = firstDate.toLocaleDateString("en-US", {
+    month: "short", day: "numeric", year: "numeric",
+  });
+
+  // ── Inject badge ──────────────────────────────────────────────────────────
+  const badge = document.createElement("div");
+  badge.id = "visitor-badge";
+  badge.className = "visitor-badge";
+  badge.innerHTML = `
+    <span class="vb-pulse"></span>
+    <span class="vb-text">
+      Your visit <strong>#${visits}</strong>
+      <span class="vb-sep">·</span>
+      <span class="vb-global" id="vb-global" title="Total page views">
+        <i class="fas fa-globe" style="font-size:0.75rem;margin-right:2px;"></i>
+        <span id="vb-global-count">…</span> visitors
+      </span>
+    </span>
+  `;
+  document.body.appendChild(badge);
+
+  // First-visit tooltip
+  if (visits === 1) {
+    const tip = document.createElement("div");
+    tip.className = "vb-welcome-tip";
+    tip.textContent = "👋 Welcome! First time here?";
+    document.body.appendChild(tip);
+    setTimeout(() => tip.classList.add("vb-welcome-show"), 200);
+    setTimeout(() => {
+      tip.classList.remove("vb-welcome-show");
+      setTimeout(() => tip.remove(), 500);
+    }, 4000);
+  }
+
+  // ── Global counter via CountAPI ───────────────────────────────────────────
+  // Free tier — namespace + key uniquely identify this counter
+  const globalCountEl = document.getElementById("vb-global-count");
+  fetch("https://api.countapi.xyz/hit/ak-portfolio-anil-kumar-2025/visitors")
+    .then((r) => r.json())
+    .then((data) => {
+      if (data?.value && globalCountEl) {
+        globalCountEl.textContent = data.value.toLocaleString();
+      }
+    })
+    .catch(() => {
+      // silently fall back — don't show broken UI
+      const globalEl = document.getElementById("vb-global");
+      if (globalEl) globalEl.style.display = "none";
+    });
+
+  // ── Hide after scroll (unobtrusive) ──────────────────────────────────────
+  let hidden = false;
+  window.addEventListener("scroll", () => {
+    if (window.scrollY > 300 && !hidden) {
+      badge.classList.add("vb-faded");
+      hidden = true;
+    } else if (window.scrollY <= 100 && hidden) {
+      badge.classList.remove("vb-faded");
+      hidden = false;
+    }
+  }, { passive: true });
+})();

--- a/styles/about_styles.css
+++ b/styles/about_styles.css
@@ -16,12 +16,12 @@
 .name {
   display: inline-block;
   font-weight: 900;
+  font-size: 3rem;
   position: relative;
   color: #ff8c00;
-  cursor: pointer;
-  transition: all 0.3s ease;
-
   cursor: vertical-text;
+  transition: all 0.3s ease;
+  letter-spacing: -0.02em;
 }
 
 .name::before {

--- a/styles/cryforhelp.css
+++ b/styles/cryforhelp.css
@@ -1,18 +1,78 @@
 .need_job {
-  padding-inline: 0.5rem;
+  padding-inline: 1.5rem;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-
-  margin-top: 10dvh;
+  gap: 2.25rem;
+  padding-top: 10dvh;
+  padding-bottom: 4rem;
 }
 
-.need_job h1 {
-  font-size: 2rem;
-  /* font-style: italic; */
-  cursor: help;
+/* h1 is now handled by fun-ui.css gradient, no override needed */
+.need_job h1 { cursor: help; }
+
+/* ── "Developers!" chant row ── */
+.cry_for_help {
+  position: relative;
+  display: inline-block;
 }
 
+.cry_for_help h3 {
+  font-size: 1.2rem !important;
+  color: var(--text-black-700);
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.cry_for_help h3:hover { color: var(--skin-color); }
+
+/* blinking cursor after the chant */
+.cry_for_help h3::after {
+  content: "▋";
+  color: var(--skin-color);
+  animation: cursor-blink 1.1s step-end infinite;
+  margin-left: 2px;
+}
+
+@keyframes cursor-blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
+}
+
+.cry_for_help img { max-width: 40dvw; }
+
+/* ── Steve Ballmer popup ── */
+#image-popup {
+  display: none;
+  position: absolute;
+  top: 100%;
+  right: 50%;
+  transform: translateX(50%);
+  margin-top: 10px;
+  border-radius: 12px;
+  padding: 12px;
+  background: #0a0a0a;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  z-index: 10;
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+#image-popup p {
+  text-align: center;
+  font-size: 0.8rem;
+  color: #aaa;
+  margin: 0;
+  padding: 6px 0 0;
+}
+
+.cry_for_help #hover-trigger:hover + #image-popup {
+  display: block;
+  opacity: 0.95;
+  transform: translateX(120%) scale(1.04);
+}
+
+/* ── Heartbeat ── */
 .white_heart {
   animation: beat 0.7s infinite;
   display: inline-block;
@@ -20,45 +80,6 @@
 }
 
 @keyframes beat {
-  0%,
-  100% {
-    transform: scale(1.2);
-  }
-  50% {
-    transform: scale(1);
-  }
-}
-
-.cry_for_help {
-  position: relative;
-  display: inline-block;
-}
-
-.cry_for_help img {
-  max-width: 40dvw;
-  /* max-height: 10vh; */
-}
-
-#image-popup {
-  display: none;
-  position: absolute;
-  /* max-width: 80dvw; */
-  top: 100%;
-  right: 50%;
-  transform: translateX(50%);
-  margin-top: 10px;
-
-  border-radius: 8px;
-  padding: 10px;
-  background-color: black;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-  z-index: 10;
-  transition: transform 0.3s ease, opacity 0.3s ease;
-  opacity: 0;
-}
-
-.cry_for_help #hover-trigger:hover + #image-popup {
-  display: block;
-  opacity: 0.9;
-  transform: translateX(120%) scale(1.05);
+  0%, 100% { transform: scale(1.2); }
+  50%       { transform: scale(1);   }
 }

--- a/styles/eagles-form.css
+++ b/styles/eagles-form.css
@@ -201,3 +201,122 @@
   color: #dc3545;
   border: 1px solid #dc3545;
 }
+
+/* ─── Direct ICS Download (primary path) ─────────────────────────────── */
+.eagles-direct-download {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.eagles-direct-label {
+  font-size: 0.9rem !important;
+  color: var(--text-black-700);
+  padding-bottom: 0;
+  margin: 0;
+}
+
+.eagles-ics-btn {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--eagles-green);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.95rem;
+  padding: 0.7rem 1.4rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+
+.eagles-ics-btn:hover:not(:disabled) {
+  filter: brightness(1.15);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 76, 84, 0.4);
+}
+
+.eagles-ics-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.eagles-direct-note {
+  font-size: 0.78rem !important;
+  color: var(--text-black-700);
+  opacity: 0.8;
+  padding-bottom: 0;
+  margin: 0;
+}
+
+.eagles-direct-status {
+  font-size: 0.88rem;
+  font-weight: 500;
+  min-height: 1.2em;
+  transition: all 0.3s ease;
+  border-radius: 6px;
+}
+
+.eagles-direct-status.status-loading { color: var(--text-black-700); }
+.eagles-direct-status.status-success {
+  color: #28a745;
+  background: rgba(40, 167, 69, 0.1);
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgba(40, 167, 69, 0.3);
+}
+.eagles-direct-status.status-error {
+  color: #dc3545;
+  background: rgba(220, 53, 69, 0.1);
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgba(220, 53, 69, 0.3);
+}
+
+.eagles-import-guide {
+  background: rgba(0, 76, 84, 0.08);
+  border: 1px solid rgba(0, 76, 84, 0.25);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-size: 0.83rem;
+  margin-top: 0.25rem;
+}
+
+.eagles-import-guide strong {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: var(--text-black-900);
+}
+
+.eagles-import-guide ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.eagles-import-guide li { color: var(--text-black-700); }
+
+/* ─── Divider between primary and email path ──────────────────────────── */
+.eagles-divider {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0.75rem 0;
+  color: var(--text-black-700);
+}
+
+.eagles-divider::before,
+.eagles-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--bg-black-50);
+}
+
+.eagles-divider span {
+  font-size: 0.8rem;
+  white-space: nowrap;
+  opacity: 0.7;
+}

--- a/styles/easter-eggs.css
+++ b/styles/easter-eggs.css
@@ -1,0 +1,245 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   Easter Egg Styles
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* ─── Toast notification ───────────────────────────────────────────────────── */
+.ee-toast {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(20px);
+  background: #1a1a2e;
+  color: #fff;
+  padding: 0.9rem 1.6rem;
+  border-radius: 50px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-align: center;
+  z-index: 9999;
+  opacity: 0;
+  border: 2px solid var(--skin-color);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  transition: opacity 0.35s ease, transform 0.35s ease;
+  pointer-events: none;
+  line-height: 1.5;
+}
+
+.ee-toast.ee-toast-show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.ee-idle-toast {
+  border-color: #4ecdc4;
+  font-size: 0.9rem;
+}
+
+/* ─── Confetti dots ────────────────────────────────────────────────────────── */
+.ee-confetti-dot {
+  position: fixed;
+  pointer-events: none;
+  z-index: 9998;
+  animation: ee-confetti-fly 1.3s ease-out forwards;
+  transform-origin: center;
+}
+
+@keyframes ee-confetti-fly {
+  0%   { transform: translate(0, 0) rotate(0deg) scale(1); opacity: 1; }
+  100% { transform: translate(var(--tx), var(--ty)) rotate(720deg) scale(0.3); opacity: 0; }
+}
+
+/* ─── HIRE ME overlay ──────────────────────────────────────────────────────── */
+#hire-me-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.82);
+  backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  opacity: 0;
+  transition: opacity 0.35s ease;
+}
+
+#hire-me-overlay.hire-me-visible {
+  opacity: 1;
+}
+
+.hire-me-box {
+  background: #1a1a1a;
+  border: 2px solid var(--skin-color);
+  border-radius: 20px;
+  padding: 2.5rem 3rem;
+  text-align: center;
+  max-width: 420px;
+  width: 90%;
+  box-shadow: 0 0 60px rgba(223, 167, 10, 0.25);
+  transform: scale(0.85);
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+#hire-me-overlay.hire-me-visible .hire-me-box {
+  transform: scale(1);
+}
+
+.hire-me-emoji {
+  font-size: 3.5rem;
+  margin-bottom: 0.5rem;
+  animation: hire-me-bounce 1s ease-in-out infinite alternate;
+}
+
+@keyframes hire-me-bounce {
+  from { transform: translateY(0); }
+  to   { transform: translateY(-10px); }
+}
+
+.hire-me-title {
+  font-size: 2.5rem;
+  font-weight: 900;
+  color: var(--skin-color);
+  letter-spacing: 0.05em;
+  margin-bottom: 0.3rem;
+  text-shadow: 0 0 20px rgba(223, 167, 10, 0.5);
+}
+
+.hire-me-subtitle {
+  font-size: 1rem;
+  color: #e9e9e9;
+  margin-bottom: 0.2rem;
+  padding-bottom: 0;
+}
+
+.hire-me-sub2 {
+  font-size: 0.85rem;
+  color: #888;
+  margin-bottom: 1.5rem;
+  padding-bottom: 0;
+}
+
+.hire-me-btn {
+  display: inline-block;
+  background: var(--skin-color);
+  color: #111;
+  font-weight: 700;
+  padding: 0.75rem 2rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-size: 1rem;
+  transition: all 0.25s ease;
+  margin-bottom: 1rem;
+}
+
+.hire-me-btn:hover {
+  filter: brightness(1.15);
+  transform: translateY(-2px);
+}
+
+.hire-me-close {
+  display: block;
+  margin: 0 auto;
+  background: none;
+  border: none;
+  color: #666;
+  font-size: 0.85rem;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+}
+
+.hire-me-close:hover { color: #aaa; }
+
+/* ─── Secret "hire" flash ──────────────────────────────────────────────────── */
+.ee-hire-flash {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.8);
+  background: rgba(51, 255, 153, 0.95);
+  color: #111;
+  font-size: 1.1rem;
+  font-weight: 800;
+  padding: 0.85rem 2rem;
+  border-radius: 999px;
+  z-index: 9999;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease, transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  white-space: nowrap;
+}
+
+.ee-hire-flash.ee-hire-flash-show {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+/* ─── Visitor badge ────────────────────────────────────────────────────────── */
+.visitor-badge {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-black-100);
+  border: 1px solid var(--bg-black-50);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.8rem;
+  color: var(--text-black-700);
+  z-index: 900;
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
+}
+
+.visitor-badge.vb-faded {
+  opacity: 0;
+  transform: translateY(6px);
+  pointer-events: none;
+}
+
+.vb-pulse {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #2ed573;
+  animation: vb-pulse-anim 1.8s ease infinite;
+  flex-shrink: 0;
+}
+
+@keyframes vb-pulse-anim {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(46, 213, 115, 0.6); }
+  50%       { box-shadow: 0 0 0 5px rgba(46, 213, 115, 0); }
+}
+
+.vb-text { display: flex; align-items: center; gap: 0.35rem; }
+.vb-sep  { opacity: 0.4; }
+.vb-global { display: flex; align-items: center; gap: 0.2rem; }
+
+/* ─── Welcome tip ──────────────────────────────────────────────────────────── */
+.vb-welcome-tip {
+  position: fixed;
+  bottom: 3.5rem;
+  left: 1rem;
+  background: var(--skin-color);
+  color: #111;
+  font-size: 0.82rem;
+  font-weight: 700;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  z-index: 901;
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  pointer-events: none;
+}
+
+.vb-welcome-tip.vb-welcome-show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ─── Mobile hide visitor badge ────────────────────────────────────────────── */
+@media (max-width: 600px) {
+  .visitor-badge { bottom: 0.6rem; left: 0.6rem; font-size: 0.72rem; }
+}

--- a/styles/fun-ui.css
+++ b/styles/fun-ui.css
@@ -1,0 +1,373 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   fun-ui.css  —  visual enhancements, animations, and personality
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* ─── Dot-grid texture on dark-mode backgrounds ──────────────────────────── */
+body.dark {
+  background-image: radial-gradient(rgba(255, 255, 255, 0.045) 1px, transparent 1px);
+  background-size: 28px 28px;
+}
+
+/* ─── Floating gradient orbs on the hero ─────────────────────────────────── */
+.need_job {
+  position: relative;
+  overflow: hidden;
+  min-height: 88dvh;
+}
+
+.need_job::before {
+  content: "";
+  position: absolute;
+  width: 560px;
+  height: 560px;
+  background: radial-gradient(circle, var(--skin-color), transparent 70%);
+  top: -180px;
+  right: -100px;
+  opacity: 0.08;
+  border-radius: 50%;
+  animation: hero-orb-float 11s ease-in-out infinite;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.need_job::after {
+  content: "";
+  position: absolute;
+  width: 380px;
+  height: 380px;
+  background: radial-gradient(circle, #6c5ce7, transparent 70%);
+  bottom: 60px;
+  left: -80px;
+  opacity: 0.06;
+  border-radius: 50%;
+  animation: hero-orb-float 15s ease-in-out infinite reverse;
+  pointer-events: none;
+  z-index: 0;
+}
+
+@keyframes hero-orb-float {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33%       { transform: translate(35px, -28px) scale(1.07); }
+  66%       { transform: translate(-22px, 18px) scale(0.94); }
+}
+
+/* make children appear above orbs */
+.need_job > * { position: relative; z-index: 1; }
+
+/* ─── Hero heading gradient text ─────────────────────────────────────────── */
+.asking_job h1 {
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  font-weight: 900;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  background: linear-gradient(135deg, var(--skin-color) 0%, #ff6b6b 55%, #a29bfe 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  cursor: help;
+}
+
+/* ─── "Open to Work" badge ───────────────────────────────────────────────── */
+.open-to-work-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  background: rgba(46, 213, 115, 0.1);
+  border: 1px solid rgba(46, 213, 115, 0.35);
+  color: #2ed573;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 0.75rem;
+}
+
+.otw-dot {
+  width: 8px;
+  height: 8px;
+  background: #2ed573;
+  border-radius: 50%;
+  flex-shrink: 0;
+  animation: otw-pulse 1.9s ease-in-out infinite;
+}
+
+@keyframes otw-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(46, 213, 115, 0.55); }
+  50%       { box-shadow: 0 0 0 5px rgba(46, 213, 115, 0); }
+}
+
+/* ─── Profession tech badges ─────────────────────────────────────────────── */
+.profession-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.35rem;
+  margin-bottom: 0.5rem;
+}
+
+.prof-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text-black-700);
+  padding: 0.28rem 0.7rem;
+  border-radius: 6px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  transition: border-color 0.25s ease, color 0.25s ease;
+}
+
+body:not(.dark) .prof-badge {
+  background: rgba(0, 0, 0, 0.04);
+  border-color: rgba(0, 0, 0, 0.1);
+}
+
+.prof-badge:hover {
+  border-color: var(--skin-color);
+  color: var(--skin-color);
+}
+
+/* ─── Hero staggered entrance ────────────────────────────────────────────── */
+@keyframes hero-slide-up {
+  from { opacity: 0; transform: translateY(28px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.need_job .cry_for_help  { animation: hero-slide-up 0.65s ease both 0.05s; }
+.need_job .asking_job    { animation: hero-slide-up 0.65s ease both 0.18s; }
+.need_job .contact-section { animation: hero-slide-up 0.65s ease both 0.32s; }
+
+/* ─── Section headings ─────────────────────────────────────────────────────
+
+   The h2 underline decorators still use --skin-color but we add a gradient
+   to the text itself in dark mode for flair.                                */
+body.dark .section_title h2 {
+  background: linear-gradient(130deg, #ffffff 55%, var(--skin-color) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  display: inline-block;
+}
+
+/* ─── Navigation sidebar improvements ───────────────────────────────────── */
+
+/* Side-bar accent bar on active/hover links */
+.aside .nav li a {
+  position: relative;
+  overflow: hidden;
+}
+
+.aside .nav li a::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 3px;
+  height: 65%;
+  background: var(--skin-color);
+  border-radius: 0 4px 4px 0;
+  transform: translateY(-50%) scaleY(0);
+  transform-origin: center;
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.aside .nav li a:hover::before,
+.aside .nav li a.active::before {
+  transform: translateY(-50%) scaleY(1);
+}
+
+/* ─── Logo shimmer animation ─────────────────────────────────────────────── */
+.aside .logo a {
+  background: linear-gradient(
+    90deg,
+    var(--text-black-900)  0%,
+    var(--skin-color)      45%,
+    var(--text-black-900)  90%
+  );
+  background-size: 250% auto;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  animation: logo-shimmer 5s linear infinite;
+}
+
+@keyframes logo-shimmer {
+  0%   { background-position: 200% center; }
+  100% { background-position: -50% center; }
+}
+
+/* ─── Project cards — gradient border shimmer on hover ───────────────────── */
+.project-card {
+  isolation: isolate;
+}
+
+.project-card::before {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: 15px;
+  background: linear-gradient(135deg, var(--skin-color), #6c5ce7 50%, #fd79a8);
+  opacity: 0;
+  z-index: -1;
+  transition: opacity 0.35s ease;
+}
+
+.project-card:hover::before { opacity: 1; }
+
+/* card inner bg needs to sit on top of the gradient border */
+.project-card:hover {
+  transform: translateY(-8px);
+  background: var(--project-card-bg);
+}
+
+/* ─── Image overlay gradient ─────────────────────────────────────────────── */
+.card-image-container {
+  position: relative;
+}
+
+.card-image-container::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 50%;
+  background: linear-gradient(to top, var(--project-card-bg), transparent);
+  pointer-events: none;
+}
+
+/* ─── Filter button glow on active ──────────────────────────────────────── */
+.filter-btn.active {
+  box-shadow: 0 0 14px rgba(223, 167, 10, 0.35);
+}
+
+/* ─── Skill description panel — glass + shimmer ─────────────────────────── */
+.skill-description-panel {
+  position: relative;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.03);
+  backdrop-filter: blur(8px);
+}
+
+/* top shimmer line */
+.skill-description-panel::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 60%;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--skin-color), transparent);
+  animation: panel-shimmer 4s ease-in-out infinite;
+}
+
+@keyframes panel-shimmer {
+  0%   { left: -60%; }
+  100% { left: 160%; }
+}
+
+/* ─── CRL stats card accent line ─────────────────────────────────────────── */
+.crl_card {
+  position: relative;
+  overflow: hidden;
+}
+
+.crl_card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--skin-color), #6c5ce7, #fd79a8);
+  border-radius: 14px 14px 0 0;
+}
+
+/* ─── Section-wide entrance animation ────────────────────────────────────── */
+@keyframes section-reveal {
+  from { opacity: 0; transform: translateY(18px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Use IntersectionObserver in JS, these classes get added when visible */
+.reveal { opacity: 0; }
+.reveal.is-visible { animation: section-reveal 0.6s ease forwards; }
+
+/* ─── Mobile contact links ────────────────────────────────────────────────── */
+.mobile_contact {
+  border-top: 1px solid var(--bg-black-50);
+  padding-top: 1rem;
+}
+
+.mobile_contact li a {
+  transition: color 0.2s ease, transform 0.2s ease;
+  display: inline-block;
+}
+
+.mobile_contact li a:hover {
+  transform: translateY(-2px);
+}
+
+/* ─── Scroll watcher gradient ─────────────────────────────────────────────── */
+.scroll_watcher {
+  background: linear-gradient(90deg, var(--skin-color), #6c5ce7, #fd79a8);
+}
+
+/* ─── Skill shelf bottom border glow ─────────────────────────────────────── */
+.shelf {
+  border-bottom-color: var(--skin-color);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2), 0 2px 0 var(--skin-color);
+}
+
+/* ─── Improved about section intro terminal look ─────────────────────────── */
+.cypher-text {
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.2);
+  border-left: 3px solid var(--skin-color);
+}
+
+body:not(.dark) .cypher-text {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+/* ─── Hover glow on email link ───────────────────────────────────────────── */
+.email-link:hover {
+  text-shadow: 0 0 12px rgba(0, 191, 255, 0.5);
+}
+
+/* ─── Soft glow on h3.hello name ─────────────────────────────────────────── */
+h3.hello span.name {
+  font-size: 3rem;
+}
+
+/* ─── CRL stat value pop on hover ────────────────────────────────────────── */
+.crl_stat_item:hover .crl_value {
+  color: var(--skin-color);
+  transition: color 0.2s ease;
+}
+
+/* ─── Better btn hover  ───────────────────────────────────────────────────── */
+.btn:hover {
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+/* ─── Tag color variation (fun rainbow tags) ──────────────────────────────── */
+.card-tag:nth-child(1)  { background: rgba(223, 167, 10,  0.15); color: #dfa70a; }
+.card-tag:nth-child(2)  { background: rgba(108, 92,  231, 0.15); color: #a29bfe; }
+.card-tag:nth-child(3)  { background: rgba(253, 121, 168, 0.15); color: #fd79a8; }
+.card-tag:nth-child(4)  { background: rgba(0,   184, 148, 0.15); color: #00b894; }
+.card-tag:nth-child(5)  { background: rgba(116, 185, 255, 0.15); color: #74b9ff; }
+.card-tag:nth-child(6)  { background: rgba(255, 107, 107, 0.15); color: #ff6b6b; }
+.card-tag:nth-child(n+7){ background: rgba(162, 155, 254, 0.15); color: #a29bfe; }
+
+/* ─── Media queries for fun-ui ────────────────────────────────────────────── */
+@media (max-width: 860px) {
+  .need_job::before { width: 300px; height: 300px; opacity: 0.06; }
+  .need_job::after  { display: none; }
+  .asking_job h1    { font-size: clamp(1.7rem, 7vw, 2.5rem); }
+}

--- a/styles/nfl-calendar.css
+++ b/styles/nfl-calendar.css
@@ -1,0 +1,265 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   NFL Team Calendar Picker
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.nfl-calendar-section {
+  padding: 2rem 1rem 3rem;
+}
+
+/* ─── Header ─────────────────────────────────────────────────────────────── */
+.nfl-section-title {
+  font-size: 1.5rem !important;
+  font-weight: 700 !important;
+  margin-bottom: 0.25rem;
+}
+
+.nfl-section-sub {
+  color: var(--text-black-700);
+  font-size: 0.95rem;
+  margin-bottom: 1.5rem;
+}
+
+/* ─── Toolbar ─────────────────────────────────────────────────────────────── */
+.nfl-toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.nfl-toolbar-btn {
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  border: 2px solid var(--skin-color);
+  background: transparent;
+  color: var(--skin-color);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+
+.nfl-toolbar-btn:hover {
+  background: var(--skin-color);
+  color: #111;
+}
+
+.nfl-selected-count {
+  font-size: 0.88rem;
+  color: var(--text-black-700);
+  margin-left: auto;
+}
+
+/* ─── Division Groups ─────────────────────────────────────────────────────── */
+.nfl-teams-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-bottom: 2rem;
+}
+
+.nfl-division-group {
+  background: var(--bg-black-100);
+  border: 1px solid var(--bg-black-50);
+  border-radius: 12px;
+  padding: 1rem 1rem 0.75rem;
+}
+
+.nfl-division-title {
+  font-size: 0.75rem !important;
+  font-weight: 700 !important;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--skin-color);
+  margin-bottom: 0.75rem;
+}
+
+.nfl-division-teams {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+/* ─── Team Card ───────────────────────────────────────────────────────────── */
+.nfl-team-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.3rem;
+
+  width: 70px;
+  padding: 0.5rem 0.4rem 0.4rem;
+  border-radius: 10px;
+  border: 2px solid var(--bg-black-50);
+  background: var(--bg-black-900);
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  outline: none;
+}
+
+.nfl-team-card:hover {
+  transform: translateY(-3px);
+  border-color: var(--tc, var(--skin-color));
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
+}
+
+.nfl-team-card.nfl-selected {
+  border-color: var(--tc, var(--skin-color));
+  background: color-mix(in srgb, var(--tc, var(--skin-color)) 12%, var(--bg-black-900));
+  box-shadow: 0 0 0 2px var(--tc, var(--skin-color)) inset;
+}
+
+/* checkmark */
+.nfl-check-icon {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--tc, var(--skin-color));
+  color: #fff;
+  font-size: 0.6rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: scale(0);
+  transition: all 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.nfl-team-card.nfl-selected .nfl-check-icon {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.nfl-logo {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  pointer-events: none;
+}
+
+.nfl-abbr {
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--text-black-900);
+  letter-spacing: 0.03em;
+}
+
+/* ─── Action bar ──────────────────────────────────────────────────────────── */
+.nfl-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-top: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.nfl-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.7rem 1.4rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: all 0.25s ease;
+}
+
+.nfl-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.nfl-btn-primary {
+  background: var(--skin-color);
+  color: #111;
+  border-color: var(--skin-color);
+}
+
+.nfl-btn-primary:hover:not(:disabled) {
+  filter: brightness(1.12);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
+}
+
+.nfl-btn-ghost {
+  background: transparent;
+  border-color: var(--bg-black-50);
+  color: var(--text-black-700);
+}
+
+.nfl-btn-ghost:hover:not(:disabled) {
+  border-color: var(--skin-color);
+  color: var(--skin-color);
+}
+
+/* ─── Status message ──────────────────────────────────────────────────────── */
+.nfl-status-msg {
+  padding: 0.65rem 1rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  margin-top: 0.5rem;
+  transition: all 0.3s ease;
+}
+
+.nfl-status-loading { color: var(--text-black-700); }
+.nfl-status-success {
+  background: rgba(46, 213, 115, 0.12);
+  color: #2ed573;
+  border: 1px solid rgba(46, 213, 115, 0.3);
+}
+.nfl-status-error {
+  background: rgba(255, 71, 87, 0.12);
+  color: #ff6b81;
+  border: 1px solid rgba(255, 71, 87, 0.3);
+}
+.nfl-status-info {
+  background: rgba(0, 191, 255, 0.1);
+  color: #00bfff;
+  border: 1px solid rgba(0, 191, 255, 0.25);
+}
+
+/* ─── Import guide ────────────────────────────────────────────────────────── */
+.nfl-import-guide {
+  background: var(--bg-black-100);
+  border: 1px solid var(--bg-black-50);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  margin-top: 1rem;
+  font-size: 0.88rem;
+}
+
+.nfl-import-guide p {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: var(--text-black-900);
+  font-size: 0.9rem !important;
+  padding-bottom: 0;
+}
+
+.nfl-import-guide ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.nfl-import-guide li {
+  color: var(--text-black-700);
+  line-height: 1.4;
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────────────── */
+@media (max-width: 600px) {
+  .nfl-team-card { width: 60px; }
+  .nfl-logo { width: 32px; height: 32px; }
+}

--- a/styles/projectStyles.css
+++ b/styles/projectStyles.css
@@ -23,12 +23,13 @@
   background: transparent;
   border: 2px solid var(--skin-color);
   color: var(--skin-color);
-  padding: 0.6rem 1.25rem;
-  border-radius: 999px; /* Pill shape */
-  font-size: 0.9rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.3s ease;
+  transition: all 0.25s ease;
+  letter-spacing: 0.02em;
 }
 
 .filter-btn:hover {
@@ -318,3 +319,42 @@
 .modal-iframe.loaded {
   opacity: 1;
 }
+
+/* ── Pinned ribbon ─────────────────────────────────────────────────────────── */
+.project-card { position: relative; }
+
+.card-pinned-ribbon {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  font-size: 1.1rem;
+  z-index: 3;
+  animation: pin-swing 3s ease-in-out infinite;
+  transform-origin: top center;
+  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.4));
+}
+
+@keyframes pin-swing {
+  0%, 100% { transform: rotate(-4deg); }
+  50%       { transform: rotate(4deg); }
+}
+
+/* ── Card title hover underline ────────────────────────────────────────────── */
+.card-title {
+  position: relative;
+  display: inline-block;
+}
+
+.card-title::after {
+  content: "";
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  width: 0;
+  height: 2px;
+  background: var(--skin-color);
+  border-radius: 999px;
+  transition: width 0.3s ease;
+}
+
+.project-card:hover .card-title::after { width: 100%; }

--- a/styles/skills_Styles.css
+++ b/styles/skills_Styles.css
@@ -137,3 +137,35 @@
     transform: translateY(0);
   }
 }
+
+/* ── Panel content pop animation when a new skill is hovered ── */
+@keyframes panel-content-pop {
+  0%   { opacity: 0; transform: translateY(6px) scale(0.98); }
+  100% { opacity: 1; transform: translateY(0)   scale(1);    }
+}
+
+.skill-description-panel.panel-pop {
+  animation: panel-content-pop 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+/* ── Bigger, more readable book spines ── */
+.book {
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+}
+
+/* ── Shelf title badge look ── */
+.shelf-title {
+  font-size: 0.7rem !important;
+  font-weight: 800 !important;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 4px;
+  padding: 0.2rem 0.5rem;
+  display: inline-block;
+  margin-bottom: 0.5rem;
+  letter-spacing: 0.1em;
+}
+
+body:not(.dark) .shelf-title {
+  background: rgba(0, 0, 0, 0.06);
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -162,22 +162,22 @@ h2 {
   content: "";
   height: 4px;
   width: 50px;
-  background-color: var(--skin-color);
+  background: linear-gradient(90deg, var(--skin-color), #6c5ce7);
   position: absolute;
   bottom: 0;
-  /* left: 0; */
+  left: 0;
+  border-radius: 999px;
 }
 
 .section_title h2::after {
   content: "";
   height: 4px;
   width: 25px;
-  background-color: var(--skin-color);
+  background: linear-gradient(90deg, #6c5ce7, #fd79a8);
   position: absolute;
-  /* bottom: -3; */
-  /* left: 0; */
   bottom: -8px;
   left: 0;
+  border-radius: 999px;
 }
 
 .row {


### PR DESCRIPTION
## What changed

### `styles/fun-ui.css` (new file — the heart of this PR)

| Effect | How |
|---|---|
| Dot-grid texture | `body.dark` radial-gradient background-image |
| Floating gradient orbs on hero | CSS `::before`/`::after` pseudo-elements with `radial-gradient` + float keyframe |
| Hero h1 gradient text | `linear-gradient` clipped to text via `-webkit-background-clip` |
| "Open to Work" badge | Inline-flex pill with pulsing green dot animation |
| Profession tech pills | Three lightweight chip badges (Full Stack / DevOps / CI/CD) |
| Hero staggered entrance | `@keyframes hero-slide-up` on `.cry_for_help`, `.asking_job`, `.contact-section` with staggered delays |
| Nav active/hover accent bar | `::before` pseudo on `<a>` that `scaleY` animates in |
| Logo shimmer | `background-position` animation across a gradient clip |
| Project card gradient border | `::before` pseudo with gradient + mask-composite trick; fades in on hover |
| Card image gradient overlay | `::after` on `.card-image-container` for bottom fade |
| Filter button glow | `box-shadow` on `.filter-btn.active` |
| Skill panel glass + shimmer | `backdrop-filter`, subtle background, top shimmer line sweep |
| CRL stats card top bar | 3px gradient line via `::before` |
| Scroll watcher bar | Tri-color gradient instead of flat skin-color |
| Rainbow card tags | `nth-child` selectors give each tag position its own color pair |
| Section heading gradient | Dark-mode `background-clip: text` gradient on `h2` |
| Heading underlines | `linear-gradient` instead of flat color on `::before`/`::after` |

---

### Hero Section
- Restored the **missing `color-1.css` active import** (PR #23 removed the non-disabled copy, so `--skin-color` was undefined on load — everything using it was broken)
- Added **"Open to Work 🟢"** animated badge
- Added **profession pill badges** (Full Stack Dev, DevOps & Cloud, CI/CD Pipelines)
- `h1` now renders as a tri-color gradient

### Project Cards
- **3D tilt effect** via JS `MutationObserver` — each card tracks the mouse and rotates up to 7° on both axes, resets on leave
- **Pinned ribbon** — pinned projects get a 📌 emoji with a swinging CSS animation in the top-right corner
- **Card title underline** — animates in from left on hover
- **GitHub icon** on "View Code" button, **eye icon** on "Quick Look"

### Skills Section
- **`panel-pop` animation** — when you hover a book, the description panel content bounces in rather than snapping instantly
- Shelf title styled as a chip/badge
- Book spine text improved (font-size + letter-spacing)

### Other improvements
- **Count-up animation** on the years-of-experience line (counts from 0.0 → actual value on load)
- **IntersectionObserver scroll-reveal** — sections fade+slide up as they enter the viewport
- **Blinking block cursor** after the "Developers!" chant line
- **Ballmer popup** upgraded with border + stronger shadow
- Cypher text intro gets a left accent border (terminal feel)

## Test plan
- [ ] Hero: gradient heading, orbs visible in dark mode, badge shows, entrance animations play once
- [ ] Skin color renders correctly (gold/orange) — no missing `--skin-color` fallback
- [ ] Scroll down past 400px — scroll-to-top button appears
- [ ] Nav links show accent bar on active section
- [ ] Logo shimmers continuously
- [ ] Hover a project card — 3D tilt follows mouse, resets on leave, gradient border appears, title underlines
- [ ] Pinned projects have a 📌 ribbon that swings
- [ ] Filter buttons show a glow when active
- [ ] Hover a skill book — description panel content bounces in
- [ ] Years of experience counts up from 0.0 on load
- [ ] Sections fade+slide in as you scroll to them
- [ ] Clash Royale card has the top gradient accent line
- [ ] Dark mode: dot grid texture visible on background

https://claude.ai/code/session_01ADNAYMar8TbZkUckDBmoPu

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADNAYMar8TbZkUckDBmoPu)_