### PR TITLE
Add NFL calendar picker, fix Eagles calendar, Easter eggs & visitor tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,36 +209,72 @@
               </div>
 
               <div class="card-body">
-                <p class="birds_accent">
-                  <span class="birds_accent">GO BIRDS! 🦅</span>
-                </p>
+                <p class="birds_accent">GO BIRDS! 🦅</p>
 
-                <!-- Primary: direct ICS download powered by ESPN live data -->
-                <div class="eagles-direct-download">
-                  <p class="eagles-direct-label">📅 Add all games instantly — no email needed:</p>
-                  <button id="eagles-direct-ics" class="btn eagles-ics-btn">
-                    <i class="fas fa-download"></i> Download Eagles Schedule (.ics)
+                <!-- Step guide -->
+                <ol class="eagles-steps" id="eagles-steps">
+                  <li class="eagles-step active" id="estep-1">
+                    <span class="estep-num">1</span>
+                    <span class="estep-label">Click <strong>Download</strong> below</span>
+                    <i class="fas fa-check estep-check"></i>
+                  </li>
+                  <li class="eagles-step" id="estep-2">
+                    <span class="estep-num">2</span>
+                    <span class="estep-label">Open the downloaded <code>.ics</code> file</span>
+                    <i class="fas fa-check estep-check"></i>
+                  </li>
+                  <li class="eagles-step" id="estep-3">
+                    <span class="estep-num">3</span>
+                    <span class="estep-label">All Eagles games on your calendar! 🎉</span>
+                    <i class="fas fa-check estep-check"></i>
+                  </li>
+                </ol>
+
+                <!-- Primary CTA -->
+                <div class="eagles-cta-wrap">
+                  <button id="eagles-direct-ics" class="eagles-download-btn" disabled>
+                    <span class="eagles-dl-left">
+                      <i class="fas fa-spinner fa-spin eagles-dl-spinner"></i>
+                      <i class="fas fa-download eagles-dl-icon"></i>
+                    </span>
+                    <span class="eagles-dl-center">
+                      <span id="eagles-btn-label">Fetching schedule…</span>
+                      <span id="eagles-game-count" class="eagles-game-count"></span>
+                    </span>
                   </button>
-                  <p class="eagles-direct-note">Works with Apple Calendar, Google Calendar &amp; Outlook · Always up-to-date from ESPN</p>
-                  <div id="eagles-direct-status" class="eagles-direct-status"></div>
-                  <div id="eagles-import-guide" class="eagles-import-guide" hidden>
-                    <strong>How to import:</strong>
-                    <ul>
-                      <li>🍎 <b>Apple Calendar</b>: Double-click the downloaded file</li>
-                      <li>📅 <b>Google Calendar</b>: Settings → Import → Upload the file</li>
-                      <li>📧 <b>Outlook</b>: File → Open &amp; Export → Import/Export</li>
-                    </ul>
+                  <p class="eagles-cta-note">Live from ESPN · No signup · Works with every calendar app</p>
+                  <div id="eagles-direct-status" class="eagles-status-msg" hidden></div>
+                </div>
+
+                <!-- Post-download calendar shortcuts -->
+                <div id="eagles-cal-shortcuts" class="eagles-cal-shortcuts" hidden>
+                  <p class="eagles-shortcuts-heading">Now import the file into your calendar:</p>
+                  <div class="eagles-shortcut-row">
+                    <a href="https://calendar.google.com/calendar/r/settings/import"
+                       target="_blank" rel="noopener noreferrer"
+                       class="eagles-shortcut-btn">
+                      <i class="fas fa-calendar"></i> Google Calendar
+                    </a>
+                    <span class="eagles-shortcut-btn eagles-shortcut-static">
+                      <i class="fab fa-apple"></i> Apple Cal — double-click the file
+                    </span>
+                    <a href="https://outlook.live.com/calendar/0/options/calendar/SharedCalendars"
+                       target="_blank" rel="noopener noreferrer"
+                       class="eagles-shortcut-btn">
+                      <i class="fas fa-envelope"></i> Outlook
+                    </a>
                   </div>
                 </div>
 
-                <div class="eagles-divider"><span>or get calendar invites via email</span></div>
+                <!-- Divider to secondary path -->
+                <div class="eagles-divider"><span>or get email invites</span></div>
 
+                <!-- Email invite form -->
                 <form id="inviteForm" class="invite_form">
                   <div class="form-group" id="formGroup">
                     <div class="marquee-text">
                       <span>"Fly Eagles Fly!" 🦅🏈</span>
                     </div>
-
                     <input
                       type="email"
                       id="email"
@@ -247,13 +283,11 @@
                       required
                     />
                   </div>
-
                   <button type="submit" id="submitButton" class="btn">
                     <span class="button-text">Get Invites</span>
                     <i class="fa-solid fa-football spinner-icon"></i>
                     <div class="spinner"></div>
                   </button>
-
                   <div id="responseMessage">
                     <i id="responseIcon" class="fa-solid"></i>
                     <span id="responseText"></span>

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
       type="image/x-icon"
     />
 
+    <link rel="stylesheet" href="./styles/color-1.css" />
     <link rel="stylesheet" href="./styles/styles.css" />
 
     <link rel="stylesheet" href="./styles/style_switcher.css" />
@@ -70,6 +71,7 @@
     <link rel="stylesheet" href="./styles/cryforhelp.css" />
     <link rel="stylesheet" href="./styles/nfl-calendar.css" />
     <link rel="stylesheet" href="./styles/easter-eggs.css" />
+    <link rel="stylesheet" href="./styles/fun-ui.css" />
 
     <link
       rel="stylesheet"
@@ -137,16 +139,19 @@
         </div>
 
         <div class="asking_job">
-          <!-- <br /> -->
+          <div class="open-to-work-badge">
+            <span class="otw-dot"></span>
+            Open to Work
+          </div>
           <h1>Welp, I Need a Job 🧑‍💻</h1>
-          <p>Full Stack & DevCloudOps Engineer</p>
+          <div class="profession-badges">
+            <span class="prof-badge"><i class="fas fa-code"></i> Full Stack Dev</span>
+            <span class="prof-badge"><i class="fas fa-cloud"></i> DevOps &amp; Cloud</span>
+            <span class="prof-badge"><i class="fas fa-layer-group"></i> CI/CD Pipelines</span>
+          </div>
           <p>
-            <i
-              ><strong
-                >I <span>enjoy</span> building Web application products and
-                efficient CI/CD pipelines!</strong
-              ></i
-            >
+            <i><strong>I <span>enjoy</span> building Web application products and
+                efficient CI/CD pipelines!</strong></i>
           </p>
           <p id="years_experience"></p>
         </div>

--- a/index.html
+++ b/index.html
@@ -68,6 +68,8 @@
     <link rel="stylesheet" href="./styles/musicSection.css" />
     <link rel="stylesheet" href="./styles/projectStyles.css" />
     <link rel="stylesheet" href="./styles/cryforhelp.css" />
+    <link rel="stylesheet" href="./styles/nfl-calendar.css" />
+    <link rel="stylesheet" href="./styles/easter-eggs.css" />
 
     <link
       rel="stylesheet"
@@ -205,6 +207,27 @@
                 <p class="birds_accent">
                   <span class="birds_accent">GO BIRDS! 🦅</span>
                 </p>
+
+                <!-- Primary: direct ICS download powered by ESPN live data -->
+                <div class="eagles-direct-download">
+                  <p class="eagles-direct-label">📅 Add all games instantly — no email needed:</p>
+                  <button id="eagles-direct-ics" class="btn eagles-ics-btn">
+                    <i class="fas fa-download"></i> Download Eagles Schedule (.ics)
+                  </button>
+                  <p class="eagles-direct-note">Works with Apple Calendar, Google Calendar &amp; Outlook · Always up-to-date from ESPN</p>
+                  <div id="eagles-direct-status" class="eagles-direct-status"></div>
+                  <div id="eagles-import-guide" class="eagles-import-guide" hidden>
+                    <strong>How to import:</strong>
+                    <ul>
+                      <li>🍎 <b>Apple Calendar</b>: Double-click the downloaded file</li>
+                      <li>📅 <b>Google Calendar</b>: Settings → Import → Upload the file</li>
+                      <li>📧 <b>Outlook</b>: File → Open &amp; Export → Import/Export</li>
+                    </ul>
+                  </div>
+                </div>
+
+                <div class="eagles-divider"><span>or get calendar invites via email</span></div>
+
                 <form id="inviteForm" class="invite_form">
                   <div class="form-group" id="formGroup">
                     <div class="marquee-text">
@@ -231,6 +254,44 @@
                     <span id="responseText"></span>
                   </div>
                 </form>
+              </div>
+            </div>
+          </div>
+
+          <!-- NFL Team Calendar Picker -->
+          <div class="nfl-calendar-wrapper row">
+            <div class="padd_15 nfl-calendar-section" style="width:100%">
+              <h3 class="nfl-section-title">🏈 Add Any NFL Team to Your Calendar</h3>
+              <p class="nfl-section-sub">
+                Pick one or more teams — schedules are fetched live from ESPN and exported as a standard .ics file that works everywhere.
+              </p>
+
+              <div class="nfl-toolbar">
+                <button class="nfl-toolbar-btn" id="nfl-select-all-btn">Select All 32</button>
+                <button class="nfl-toolbar-btn" id="nfl-clear-btn">Clear</button>
+                <span class="nfl-selected-count" id="nfl-selected-count">No teams selected</span>
+              </div>
+
+              <div class="nfl-teams-grid" id="nfl-teams-grid"></div>
+
+              <div class="nfl-actions">
+                <button class="nfl-btn nfl-btn-primary" id="nfl-download-ics" disabled>
+                  <i class="fas fa-download"></i> Download .ics
+                </button>
+                <button class="nfl-btn nfl-btn-ghost" id="nfl-clear-btn-2">
+                  <i class="fas fa-times"></i> Clear
+                </button>
+              </div>
+
+              <div id="nfl-status"></div>
+
+              <div id="nfl-import-guide" class="nfl-import-guide" hidden>
+                <p>How to import into your calendar:</p>
+                <ul>
+                  <li>🍎 <strong>Apple Calendar</strong>: Double-click the .ics file</li>
+                  <li>📅 <strong>Google Calendar</strong>: Settings ⚙️ → Import → Upload file</li>
+                  <li>📧 <strong>Outlook</strong>: File → Open &amp; Export → Import/Export</li>
+                </ul>
               </div>
             </div>
           </div>
@@ -462,5 +523,8 @@
 
     <script src="./scripts/script.js"></script>
     <script src="./scripts/style-switcher.js"></script>
+    <script src="./scripts/nfl-calendar.js"></script>
+    <script src="./scripts/easter-eggs.js"></script>
+    <script src="./scripts/visitor-tracker.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
     <link rel="stylesheet" href="./styles/nfl-calendar.css" />
     <link rel="stylesheet" href="./styles/easter-eggs.css" />
     <link rel="stylesheet" href="./styles/fun-ui.css" />
+    <link rel="stylesheet" href="./styles/animations.css" />
 
     <link
       rel="stylesheet"
@@ -84,6 +85,9 @@
   </head>
 
   <body class="dark">
+    <div id="cursor-dot" class="cursor-dot"></div>
+    <div id="cursor-ring" class="cursor-ring"></div>
+    <div id="section-dots" class="section-dots"></div>
     <div class="scroll_watcher"></div>
     <!-- <div id="blob"></div> -->
     <div class="aside">
@@ -125,6 +129,7 @@
 
     <main class="main_content flex_col">
       <section class="need_job section" id="home">
+        <canvas id="hero-particles"></canvas>
         <div class="cry_for_help">
           <h3 id="hover-trigger">Developers! Developers Developers! 👏</h3>
 
@@ -565,5 +570,6 @@
     <script src="./scripts/nfl-calendar.js"></script>
     <script src="./scripts/easter-eggs.js"></script>
     <script src="./scripts/visitor-tracker.js"></script>
+    <script src="./scripts/animations.js" defer></script>
   </body>
 </html>

--- a/scripts/animations.js
+++ b/scripts/animations.js
@@ -1,0 +1,285 @@
+/* animations.js — cursor, particles, section dots, ripple, count-up, timeline */
+
+(function () {
+  "use strict";
+
+  const reduced  = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const isTouch  = window.matchMedia("(pointer: coarse)").matches;
+  const isDesktop = window.matchMedia("(min-width: 1261px)").matches;
+
+  // ── Custom Cursor ────────────────────────────────────────────────────────────
+  const dot  = document.getElementById("cursor-dot");
+  const ring = document.getElementById("cursor-ring");
+
+  if (!isTouch && !reduced && dot && ring) {
+    let mx = -100, my = -100, rx = -100, ry = -100;
+    let rafCursor;
+
+    document.addEventListener("mousemove", (e) => {
+      mx = e.clientX; my = e.clientY;
+      dot.style.left = mx + "px";
+      dot.style.top  = my + "px";
+    });
+
+    function lerpRing() {
+      rx += (mx - rx) * 0.13;
+      ry += (my - ry) * 0.13;
+      ring.style.left = rx + "px";
+      ring.style.top  = ry + "px";
+      rafCursor = requestAnimationFrame(lerpRing);
+    }
+    lerpRing();
+
+    const hoverSel = "a, button, [role='button'], .card-btn, .filter-btn, .project-card, .section-dot, .style-switcher-toggler, input, .nav_toggler";
+
+    function onEnter() { dot.classList.add("cur-hover"); ring.classList.add("cur-hover"); }
+    function onLeave() { dot.classList.remove("cur-hover"); ring.classList.remove("cur-hover"); }
+
+    function attachCursorHover(el) {
+      if (el._cursorBound) return;
+      el._cursorBound = true;
+      el.addEventListener("mouseenter", onEnter);
+      el.addEventListener("mouseleave", onLeave);
+    }
+
+    document.querySelectorAll(hoverSel).forEach(attachCursorHover);
+
+    // Pick up dynamically-added project cards
+    const pgrid = document.getElementById("projects-grid");
+    if (pgrid) {
+      new MutationObserver(() => {
+        pgrid.querySelectorAll(".project-card").forEach(attachCursorHover);
+      }).observe(pgrid, { childList: true });
+    }
+
+    document.addEventListener("mouseleave", () => { dot.classList.add("cur-gone"); ring.classList.add("cur-gone"); });
+    document.addEventListener("mouseenter", () => { dot.classList.remove("cur-gone"); ring.classList.remove("cur-gone"); });
+  }
+
+  // ── Hero Particles ────────────────────────────────────────────────────────────
+  if (!reduced) {
+    const canvas = document.getElementById("hero-particles");
+    if (canvas) {
+      const ctx   = canvas.getContext("2d");
+      const COUNT = isDesktop ? 55 : 28;
+      const DIST  = 120;
+      let W, H, particles = [];
+      let pmx = 0, pmy = 0;
+
+      function resize() {
+        const parent = canvas.parentElement;
+        W = canvas.width  = parent.offsetWidth;
+        H = canvas.height = parent.offsetHeight;
+        pmx = W / 2; pmy = H / 2;
+      }
+
+      resize();
+      window.addEventListener("resize", resize, { passive: true });
+
+      canvas.parentElement.addEventListener("mousemove", (e) => {
+        const r = canvas.getBoundingClientRect();
+        pmx = e.clientX - r.left;
+        pmy = e.clientY - r.top;
+      }, { passive: true });
+
+      function mkParticle() {
+        return {
+          x:  Math.random() * W,
+          y:  Math.random() * H,
+          vx: (Math.random() - 0.5) * 0.35,
+          vy: (Math.random() - 0.5) * 0.35,
+          r:  Math.random() * 1.4 + 0.5,
+          a:  Math.random() * 0.5 + 0.2,
+        };
+      }
+
+      for (let i = 0; i < COUNT; i++) particles.push(mkParticle());
+
+      function tick() {
+        ctx.clearRect(0, 0, W, H);
+        const dark  = document.body.classList.contains("dark");
+        const base  = dark ? "255,255,255" : "100,100,120";
+
+        for (let i = 0; i < particles.length; i++) {
+          const p  = particles[i];
+          const dx = p.x - pmx, dy = p.y - pmy;
+          const d  = Math.sqrt(dx * dx + dy * dy);
+          if (d < 90) { p.vx += (dx / d) * 0.06; p.vy += (dy / d) * 0.06; }
+          const spd = Math.sqrt(p.vx * p.vx + p.vy * p.vy);
+          if (spd > 1.1) { p.vx /= spd; p.vy /= spd; }
+          p.x += p.vx; p.y += p.vy;
+          if (p.x < 0) p.x = W; if (p.x > W) p.x = 0;
+          if (p.y < 0) p.y = H; if (p.y > H) p.y = 0;
+
+          ctx.beginPath();
+          ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+          ctx.fillStyle = `rgba(${base},${p.a})`;
+          ctx.fill();
+
+          for (let j = i + 1; j < particles.length; j++) {
+            const q   = particles[j];
+            const ddx = p.x - q.x, ddy = p.y - q.y;
+            const dd  = Math.sqrt(ddx * ddx + ddy * ddy);
+            if (dd < DIST) {
+              ctx.beginPath();
+              ctx.moveTo(p.x, p.y);
+              ctx.lineTo(q.x, q.y);
+              ctx.strokeStyle = `rgba(${base},${(1 - dd / DIST) * 0.12})`;
+              ctx.lineWidth   = 0.5;
+              ctx.stroke();
+            }
+          }
+        }
+        requestAnimationFrame(tick);
+      }
+      tick();
+    }
+  }
+
+  // ── Section Progress Dots ─────────────────────────────────────────────────────
+  document.addEventListener("DOMContentLoaded", () => {
+    const container = document.getElementById("section-dots");
+    if (!container) return;
+
+    const SECTIONS = [
+      { id: "home",      label: "Home" },
+      { id: "portfolio", label: "Projects" },
+      { id: "about",     label: "About" },
+    ];
+
+    SECTIONS.forEach(({ id, label }) => {
+      const d = document.createElement("div");
+      d.className       = "section-dot";
+      d.dataset.target  = id;
+      d.dataset.label   = label;
+      d.title           = label;
+      d.addEventListener("click", () => {
+        document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+      });
+      container.appendChild(d);
+    });
+
+    const allDots = container.querySelectorAll(".section-dot");
+
+    function sync() {
+      let cur = SECTIONS[0].id;
+      SECTIONS.forEach(({ id }) => {
+        const el = document.getElementById(id);
+        if (el && window.scrollY >= el.offsetTop - 220) cur = id;
+      });
+      allDots.forEach((d) => d.classList.toggle("sd-active", d.dataset.target === cur));
+    }
+
+    window.addEventListener("scroll", sync, { passive: true });
+    sync();
+  });
+
+  // ── Button Ripple ─────────────────────────────────────────────────────────────
+  document.addEventListener("DOMContentLoaded", () => {
+    const SEL = ".btn, .card-btn, .filter-btn, .eagles-download-btn, .nfl-btn";
+
+    function addRipple(btn) {
+      if (btn._rippleBound) return;
+      btn._rippleBound = true;
+      btn.addEventListener("click", (e) => {
+        const r    = btn.getBoundingClientRect();
+        const size = Math.max(r.width, r.height);
+        const span = document.createElement("span");
+        span.className  = "ripple";
+        span.style.cssText = `
+          width:${size}px;height:${size}px;
+          left:${e.clientX - r.left - size/2}px;
+          top:${e.clientY - r.top  - size/2}px;
+        `;
+        btn.appendChild(span);
+        setTimeout(() => span.remove(), 620);
+      });
+    }
+
+    document.querySelectorAll(SEL).forEach(addRipple);
+
+    // Pick up dynamically added buttons (NFL team cards, project buttons)
+    new MutationObserver(() => {
+      document.querySelectorAll(SEL).forEach(addRipple);
+    }).observe(document.body, { childList: true, subtree: true });
+  });
+
+  // ── Timeline Entrance ─────────────────────────────────────────────────────────
+  document.addEventListener("DOMContentLoaded", () => {
+    const items = document.querySelectorAll(".timeline_item");
+    if (!items.length || reduced) {
+      items.forEach((el) => el.classList.add("tl-visible"));
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => entries.forEach((e) => {
+        if (e.isIntersecting) { e.target.classList.add("tl-visible"); io.unobserve(e.target); }
+      }),
+      { threshold: 0.25 }
+    );
+    items.forEach((el) => io.observe(el));
+  });
+
+  // ── CRL Stats Count-up ────────────────────────────────────────────────────────
+  document.addEventListener("DOMContentLoaded", () => {
+    const card = document.querySelector(".crl_card");
+    if (!card || reduced) return;
+
+    function runCountUp() {
+      card.querySelectorAll(".crl_value").forEach((el) => {
+        if (el._counted) return;
+        const raw = el.textContent.trim();
+        const num = parseFloat(raw.replace(/,/g, ""));
+        if (isNaN(num) || num === 0) return;
+        el._counted  = true;
+        el.classList.add("crl-counting");
+        const start = performance.now();
+        const DUR   = 1100;
+        function step(now) {
+          const t = Math.min((now - start) / DUR, 1);
+          const e = 1 - Math.pow(1 - t, 3);
+          el.textContent = Math.round(e * num).toLocaleString();
+          if (t < 1) requestAnimationFrame(step);
+          else { el.textContent = raw; el.classList.remove("crl-counting"); }
+        }
+        requestAnimationFrame(step);
+      });
+    }
+
+    const io = new IntersectionObserver(
+      (entries) => { if (entries[0].isIntersecting) { runCountUp(); io.disconnect(); } },
+      { threshold: 0.5 }
+    );
+    io.observe(card);
+
+    // Also trigger if already in view when stats load (Clash Royale fetch)
+    const crlObserver = new MutationObserver(() => {
+      const val = card.querySelector(".crl_value");
+      if (val && val.textContent !== "Loading..." && val.textContent !== "N/A") {
+        const rect = card.getBoundingClientRect();
+        if (rect.top < window.innerHeight) runCountUp();
+      }
+    });
+    crlObserver.observe(card, { subtree: true, childList: true, characterData: true });
+  });
+
+  // ── Magnetic effect on hero CTA ───────────────────────────────────────────────
+  if (!isTouch && isDesktop && !reduced) {
+    document.addEventListener("DOMContentLoaded", () => {
+      document.querySelectorAll(".btn, .open-to-work-badge").forEach((btn) => {
+        btn.addEventListener("mousemove", (e) => {
+          const r  = btn.getBoundingClientRect();
+          const cx = r.left + r.width  / 2;
+          const cy = r.top  + r.height / 2;
+          const dx = (e.clientX - cx) * 0.25;
+          const dy = (e.clientY - cy) * 0.25;
+          btn.style.transform = `translate(${dx}px, ${dy}px)`;
+        });
+        btn.addEventListener("mouseleave", () => {
+          btn.style.transform = "";
+        });
+      });
+    });
+  }
+
+})();

--- a/scripts/calendarInvite.js
+++ b/scripts/calendarInvite.js
@@ -5,13 +5,13 @@
  */
 document.addEventListener("DOMContentLoaded", () => {
   // ── Email-based invite (secondary path) ──────────────────────────────────
-  const form              = document.getElementById("inviteForm");
-  const emailInput        = document.getElementById("email");
-  const submitButton      = document.getElementById("submitButton");
-  const formGroup         = document.getElementById("formGroup");
+  const form               = document.getElementById("inviteForm");
+  const emailInput         = document.getElementById("email");
+  const submitButton       = document.getElementById("submitButton");
+  const formGroup          = document.getElementById("formGroup");
   const responseMessageDiv = document.getElementById("responseMessage");
-  const responseIcon      = document.getElementById("responseIcon");
-  const responseText      = document.getElementById("responseText");
+  const responseIcon       = document.getElementById("responseIcon");
+  const responseText       = document.getElementById("responseText");
 
   const SCRIPT_URL =
     "https://script.google.com/macros/s/AKfycbyYmu3bPV2n79YBC1uSPphErMxAGGrAmwLbR-QzqLtu71LrxemqDldZaj0K-w-FVciFVg/exec";
@@ -63,53 +63,113 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   // ── Direct ICS download (primary path) ───────────────────────────────────
-  const EAGLES_TEAM_ID = "21"; // ESPN team ID for Philadelphia Eagles
+  const EAGLES_TEAM_ID = "21";
 
-  const directBtn   = document.getElementById("eagles-direct-ics");
-  const directStatus = document.getElementById("eagles-direct-status");
+  const directBtn     = document.getElementById("eagles-direct-ics");
+  const btnLabel      = document.getElementById("eagles-btn-label");
+  const gameCountEl   = document.getElementById("eagles-game-count");
+  const statusMsg     = document.getElementById("eagles-direct-status");
+  const calShortcuts  = document.getElementById("eagles-cal-shortcuts");
+  const step1         = document.getElementById("estep-1");
+  const step2         = document.getElementById("estep-2");
+  const step3         = document.getElementById("estep-3");
 
   if (!directBtn) return;
 
-  directBtn.addEventListener("click", async () => {
-    directBtn.disabled = true;
-    directBtn.innerHTML = `<i class="fas fa-spinner fa-spin"></i> Fetching schedule…`;
-    setDirectStatus("Fetching live schedule from ESPN…", "loading");
+  // Cache fetched games so the download is instant on click
+  let cachedGames = null;
+  let fetchFailed = false;
 
+  // ── Pre-fetch on page load ────────────────────────────────────────────────
+  (async () => {
     try {
       const data  = await fetchEaglesSchedule();
-      const games = parseEaglesGames(data);
+      cachedGames = parseEaglesGames(data);
 
-      if (games.length === 0) {
-        setDirectStatus("No upcoming games found. Check back later!", "error");
+      if (cachedGames.length === 0) {
+        setBtnReady(0, true);
+        showStatus("No upcoming games found — check back closer to the season.", "error");
         return;
       }
 
-      const ics = buildICS(games);
-      triggerDownload(ics, "eagles-2025-schedule.ics");
-      setDirectStatus(
-        `✅ Downloaded ${games.length} Eagles games! Import the file into your calendar app.`,
-        "success"
-      );
-
-      // Show import guide
-      const guide = document.getElementById("eagles-import-guide");
-      if (guide) guide.hidden = false;
+      setBtnReady(cachedGames.length, false);
     } catch (err) {
-      console.error("Eagles ICS error:", err);
-      setDirectStatus(
-        "❌ Could not reach ESPN. Check your connection and try again.",
-        "error"
-      );
-    } finally {
-      directBtn.disabled = false;
-      directBtn.innerHTML = `<i class="fas fa-download"></i> Download Eagles Schedule (.ics)`;
+      console.error("Eagles pre-fetch error:", err);
+      fetchFailed = true;
+      setBtnReady(0, true);
+      showStatus("Couldn't reach ESPN. Click the button to retry.", "error");
     }
+  })();
+
+  // ── Click handler ─────────────────────────────────────────────────────────
+  directBtn.addEventListener("click", async () => {
+    // Retry fetch if it previously failed
+    if (fetchFailed || !cachedGames) {
+      directBtn.disabled = true;
+      setBtnLoading(true);
+      try {
+        const data  = await fetchEaglesSchedule();
+        cachedGames = parseEaglesGames(data);
+        fetchFailed = false;
+        setBtnReady(cachedGames.length, false);
+      } catch (err) {
+        showStatus("❌ Still can't reach ESPN. Check your connection.", "error");
+        setBtnReady(0, true);
+        return;
+      } finally {
+        directBtn.disabled = false;
+        setBtnLoading(false);
+      }
+    }
+
+    if (!cachedGames || cachedGames.length === 0) return;
+
+    // Trigger download
+    const ics = buildICS(cachedGames);
+    triggerDownload(ics, "eagles-2025-schedule.ics");
+
+    // Advance step 1 → step 2
+    if (step1) step1.classList.add("completed");
+    if (step2) step2.classList.add("active");
+
+    showStatus(`✅ ${cachedGames.length} Eagles games downloaded!`, "success");
+
+    // Reveal calendar import shortcuts
+    if (calShortcuts) calShortcuts.hidden = false;
+
+    // After a short delay, tick off step 2 and hint at step 3
+    setTimeout(() => {
+      if (step2) step2.classList.add("completed");
+      if (step3) step3.classList.add("active");
+    }, 2500);
   });
 
-  function setDirectStatus(msg, type) {
-    if (!directStatus) return;
-    directStatus.textContent = msg;
-    directStatus.className = `eagles-direct-status status-${type}`;
+  // ── UI helpers ────────────────────────────────────────────────────────────
+  function setBtnLoading(on) {
+    const spinner = directBtn.querySelector(".eagles-dl-spinner");
+    const icon    = directBtn.querySelector(".eagles-dl-icon");
+    if (spinner) spinner.style.display = on ? "" : "none";
+    if (icon)    icon.style.display    = on ? "none" : "";
+  }
+
+  function setBtnReady(count, disabled) {
+    directBtn.disabled = disabled;
+    setBtnLoading(false);
+
+    if (count > 0) {
+      if (btnLabel)    btnLabel.textContent = `Download ${count} Eagles Games (.ics)`;
+      if (gameCountEl) gameCountEl.textContent = "";
+    } else {
+      if (btnLabel)    btnLabel.textContent = "Download Eagles Schedule (.ics)";
+      if (gameCountEl) gameCountEl.textContent = "";
+    }
+  }
+
+  function showStatus(msg, type) {
+    if (!statusMsg) return;
+    statusMsg.textContent = msg;
+    statusMsg.className   = `eagles-status-msg status-${type}`;
+    statusMsg.hidden      = false;
   }
 
   // ── ESPN helpers ──────────────────────────────────────────────────────────
@@ -124,19 +184,19 @@ document.addEventListener("DOMContentLoaded", () => {
     return (data.events || [])
       .filter((e) => e.competitions?.[0])
       .map((e) => {
-        const comp    = e.competitions[0];
-        const home    = comp.competitors?.find((c) => c.homeAway === "home");
-        const away    = comp.competitors?.find((c) => c.homeAway === "away");
-        const venue   = comp.venue || {};
+        const comp     = e.competitions[0];
+        const home     = comp.competitors?.find((c) => c.homeAway === "home");
+        const away     = comp.competitors?.find((c) => c.homeAway === "away");
+        const venue    = comp.venue || {};
         const homeAbbr = home?.team?.abbreviation ?? "HOME";
         const awayAbbr = away?.team?.abbreviation ?? "AWAY";
-        const isHomeGame = home?.team?.id === EAGLES_TEAM_ID;
+        const isHomeGame = home?.team?.id === String(EAGLES_TEAM_ID);
         return {
-          uid:      e.id,
-          start:    new Date(e.date),
-          summary:  `🦅 Eagles: ${awayAbbr} @ ${homeAbbr}${isHomeGame ? " 🏟" : ""}`,
+          uid:         e.id,
+          start:       new Date(e.date),
+          summary:     `🦅 Eagles: ${awayAbbr} @ ${homeAbbr}${isHomeGame ? " 🏟" : ""}`,
           description: `Philadelphia Eagles — ${e.season?.year ?? "2025"} NFL Season\n${e.name ?? ""}`,
-          location: [venue.fullName, venue.address?.city, venue.address?.state]
+          location:    [venue.fullName, venue.address?.city, venue.address?.state]
             .filter(Boolean)
             .join(", "),
         };

--- a/scripts/calendarInvite.js
+++ b/scripts/calendarInvite.js
@@ -1,63 +1,191 @@
-document.addEventListener('DOMContentLoaded', () => {
-    const form = document.getElementById("inviteForm");
-    const emailInput = document.getElementById("email");
-    const submitButton = document.getElementById("submitButton");
-    const formGroup = document.getElementById("formGroup");
+/**
+ * Eagles Calendar Invite
+ * Primary:   Download an ICS file built in real-time from ESPN's public API
+ * Secondary: Email invite via Google Apps Script (requires user email)
+ */
+document.addEventListener("DOMContentLoaded", () => {
+  // ── Email-based invite (secondary path) ──────────────────────────────────
+  const form              = document.getElementById("inviteForm");
+  const emailInput        = document.getElementById("email");
+  const submitButton      = document.getElementById("submitButton");
+  const formGroup         = document.getElementById("formGroup");
+  const responseMessageDiv = document.getElementById("responseMessage");
+  const responseIcon      = document.getElementById("responseIcon");
+  const responseText      = document.getElementById("responseText");
 
-    const responseMessageDiv = document.getElementById("responseMessage");
-    const responseIcon = document.getElementById("responseIcon");
-    const responseText = document.getElementById("responseText");
+  const SCRIPT_URL =
+    "https://script.google.com/macros/s/AKfycbyYmu3bPV2n79YBC1uSPphErMxAGGrAmwLbR-QzqLtu71LrxemqDldZaj0K-w-FVciFVg/exec";
 
-    const SCRIPT_URL = "https://script.google.com/macros/s/AKfycbyYmu3bPV2n79YBC1uSPphErMxAGGrAmwLbR-QzqLtu71LrxemqDldZaj0K-w-FVciFVg/exec";
+  if (form) {
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
 
-    form.addEventListener('submit', (e) => {
-        e.preventDefault();
+      submitButton.disabled = true;
+      submitButton.classList.add("loading");
+      formGroup.classList.add("loading");
+      emailInput.disabled = true;
+      responseMessageDiv.classList.remove("visible", "success", "error");
 
-
-        submitButton.disabled = true;
-        submitButton.classList.add('loading');
-        formGroup.classList.add('loading');
-
-        emailInput.disabled = true;
-
-        responseMessageDiv.classList.remove('visible', 'success', 'error');
-
-        // 2. Make the fetch request to the Google Apps Script
-        fetch(SCRIPT_URL, {
-            method: 'POST',
-            body: new URLSearchParams({
-                email: emailInput.value
-            })
+      fetch(SCRIPT_URL, {
+        method: "POST",
+        redirect: "follow",
+        body: new URLSearchParams({ email: emailInput.value }),
+      })
+        .then((r) => {
+          if (!r.ok) throw new Error(`HTTP ${r.status}`);
+          return r.json();
         })
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error(`Network response was not ok: ${response.statusText}`);
-                }
-                return response.json();
-            })
-            .then(data => {
-                responseText.textContent = data.message;
-                if (data.status === 'success') {
-                    responseMessageDiv.classList.add('success');
-                    responseIcon.className = 'fa-solid fa-circle-check';
-                    form.reset();
-                } else {
-                    responseMessageDiv.classList.add('error');
-                    responseIcon.className = 'fa-solid fa-circle-xmark';
-                }
-            })
-            .catch(error => {
-                console.error("Fetch Error:", error);
-                responseMessageDiv.classList.add('error');
-                responseIcon.className = 'fa-solid fa-triangle-exclamation';
-                responseText.textContent = 'An unexpected error occurred. Please try again.';
-            })
-            .finally(() => {
-                submitButton.disabled = false;
-                submitButton.classList.remove('loading');
-                formGroup.classList.remove('loading');
-                emailInput.disabled = false
-                responseMessageDiv.classList.add('visible');
-            });
+        .then((data) => {
+          responseText.textContent = data.message;
+          responseIcon.className =
+            data.status === "success"
+              ? "fa-solid fa-circle-check"
+              : "fa-solid fa-circle-xmark";
+          responseMessageDiv.classList.add(
+            data.status === "success" ? "success" : "error"
+          );
+          if (data.status === "success") form.reset();
+        })
+        .catch(() => {
+          responseMessageDiv.classList.add("error");
+          responseIcon.className = "fa-solid fa-triangle-exclamation";
+          responseText.textContent =
+            "Couldn't reach the server. Try the direct download below instead!";
+        })
+        .finally(() => {
+          submitButton.disabled = false;
+          submitButton.classList.remove("loading");
+          formGroup.classList.remove("loading");
+          emailInput.disabled = false;
+          responseMessageDiv.classList.add("visible");
+        });
     });
+  }
+
+  // ── Direct ICS download (primary path) ───────────────────────────────────
+  const EAGLES_TEAM_ID = "21"; // ESPN team ID for Philadelphia Eagles
+
+  const directBtn   = document.getElementById("eagles-direct-ics");
+  const directStatus = document.getElementById("eagles-direct-status");
+
+  if (!directBtn) return;
+
+  directBtn.addEventListener("click", async () => {
+    directBtn.disabled = true;
+    directBtn.innerHTML = `<i class="fas fa-spinner fa-spin"></i> Fetching schedule…`;
+    setDirectStatus("Fetching live schedule from ESPN…", "loading");
+
+    try {
+      const data  = await fetchEaglesSchedule();
+      const games = parseEaglesGames(data);
+
+      if (games.length === 0) {
+        setDirectStatus("No upcoming games found. Check back later!", "error");
+        return;
+      }
+
+      const ics = buildICS(games);
+      triggerDownload(ics, "eagles-2025-schedule.ics");
+      setDirectStatus(
+        `✅ Downloaded ${games.length} Eagles games! Import the file into your calendar app.`,
+        "success"
+      );
+
+      // Show import guide
+      const guide = document.getElementById("eagles-import-guide");
+      if (guide) guide.hidden = false;
+    } catch (err) {
+      console.error("Eagles ICS error:", err);
+      setDirectStatus(
+        "❌ Could not reach ESPN. Check your connection and try again.",
+        "error"
+      );
+    } finally {
+      directBtn.disabled = false;
+      directBtn.innerHTML = `<i class="fas fa-download"></i> Download Eagles Schedule (.ics)`;
+    }
+  });
+
+  function setDirectStatus(msg, type) {
+    if (!directStatus) return;
+    directStatus.textContent = msg;
+    directStatus.className = `eagles-direct-status status-${type}`;
+  }
+
+  // ── ESPN helpers ──────────────────────────────────────────────────────────
+  async function fetchEaglesSchedule() {
+    const url = `https://site.api.espn.com/apis/site/v2/sports/football/nfl/teams/${EAGLES_TEAM_ID}/schedule`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`ESPN API ${res.status}`);
+    return res.json();
+  }
+
+  function parseEaglesGames(data) {
+    return (data.events || [])
+      .filter((e) => e.competitions?.[0])
+      .map((e) => {
+        const comp    = e.competitions[0];
+        const home    = comp.competitors?.find((c) => c.homeAway === "home");
+        const away    = comp.competitors?.find((c) => c.homeAway === "away");
+        const venue   = comp.venue || {};
+        const homeAbbr = home?.team?.abbreviation ?? "HOME";
+        const awayAbbr = away?.team?.abbreviation ?? "AWAY";
+        const isHomeGame = home?.team?.id === EAGLES_TEAM_ID;
+        return {
+          uid:      e.id,
+          start:    new Date(e.date),
+          summary:  `🦅 Eagles: ${awayAbbr} @ ${homeAbbr}${isHomeGame ? " 🏟" : ""}`,
+          description: `Philadelphia Eagles — ${e.season?.year ?? "2025"} NFL Season\n${e.name ?? ""}`,
+          location: [venue.fullName, venue.address?.city, venue.address?.state]
+            .filter(Boolean)
+            .join(", "),
+        };
+      });
+  }
+
+  // ── ICS builder ───────────────────────────────────────────────────────────
+  function toUTC(date) {
+    return date.toISOString().replace(/[-:.]/g, "").slice(0, 15) + "Z";
+  }
+
+  function buildICS(games) {
+    const lines = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//Eagles 2025 Schedule//AK Portfolio//EN",
+      "CALSCALE:GREGORIAN",
+      "METHOD:PUBLISH",
+      "X-WR-CALNAME:🦅 Eagles 2025 Season",
+      "X-WR-TIMEZONE:America/New_York",
+    ];
+
+    games.forEach((g) => {
+      const end = new Date(g.start.getTime() + 3 * 60 * 60 * 1000);
+      lines.push(
+        "BEGIN:VEVENT",
+        `UID:${g.uid}@eagles-ak-portfolio`,
+        `DTSTART:${toUTC(g.start)}`,
+        `DTEND:${toUTC(end)}`,
+        `SUMMARY:${g.summary}`,
+        `DESCRIPTION:${g.description.replace(/\n/g, "\\n")}`,
+        `LOCATION:${g.location}`,
+        "END:VEVENT"
+      );
+    });
+
+    lines.push("END:VCALENDAR");
+    return lines.join("\r\n");
+  }
+
+  function triggerDownload(content, filename) {
+    const blob = new Blob([content], { type: "text/calendar;charset=utf-8" });
+    const url  = URL.createObjectURL(blob);
+    const a    = Object.assign(document.createElement("a"), {
+      href: url, download: filename,
+    });
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
 });

--- a/scripts/easter-eggs.js
+++ b/scripts/easter-eggs.js
@@ -1,0 +1,234 @@
+/**
+ * Easter Eggs 🥚
+ * 1. Console art on load
+ * 2. Konami Code → confetti party
+ * 3. Logo clicked 5× → "HIRE ME" overlay
+ * 4. Idle 45s → cheeky message
+ * 5. Secret word "hire" typed anywhere → flash animation
+ */
+
+// ─── 1. Console art ───────────────────────────────────────────────────────────
+(function printConsoleArt() {
+  const gold  = "color:#dfa70a;font-weight:bold;";
+  const white = "color:#e9e9e9;font-size:13px;";
+  const cyan  = "color:#00bfff;font-size:13px;";
+  const green = "color:#33ff99;font-size:13px;font-weight:bold;";
+
+  console.log(
+    "%c" +
+    "    _    _  __\n" +
+    "   / \\  | |/ /\n" +
+    "  / _ \\ | ' / \n" +
+    " / ___ \\| . \\ \n" +
+    "/_/   \\_\\_|\\_\\\n",
+    "color:#dfa70a;font-family:monospace;font-size:16px;font-weight:bold;"
+  );
+  console.log("%c👀 Oh hey, you found the DevTools — respect.", white);
+  console.log("%c🚀 Built by Anil Kumar — Full Stack & DevOps Engineer", green);
+  console.log("%c📧 karapaanilkumar@gmail.com", cyan);
+  console.log(
+    "%c🔗 linkedin.com/in/anil-kumar-karapa/",
+    cyan
+  );
+  console.log(
+    "%c💡 Pro tip: try the Konami code on this page ↑↑↓↓←→←→BA",
+    gold
+  );
+})();
+
+// ─── 2. Konami Code ───────────────────────────────────────────────────────────
+(function konamiCode() {
+  const SEQUENCE = [
+    "ArrowUp","ArrowUp","ArrowDown","ArrowDown",
+    "ArrowLeft","ArrowRight","ArrowLeft","ArrowRight",
+    "b","a",
+  ];
+  let idx = 0;
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === SEQUENCE[idx]) {
+      idx++;
+      if (idx === SEQUENCE.length) {
+        idx = 0;
+        triggerPartyMode();
+      }
+    } else {
+      idx = e.key === SEQUENCE[0] ? 1 : 0;
+    }
+  });
+
+  function triggerPartyMode() {
+    // Toast
+    const toast = document.createElement("div");
+    toast.className = "ee-toast";
+    toast.innerHTML =
+      "<span>🎉 DEVELOPER MODE ACTIVATED 🎉</span><br><small>Konami code unlocked!</small>";
+    document.body.appendChild(toast);
+    setTimeout(() => toast.classList.add("ee-toast-show"), 10);
+    setTimeout(() => {
+      toast.classList.remove("ee-toast-show");
+      setTimeout(() => toast.remove(), 400);
+    }, 3000);
+
+    // Big confetti burst
+    burstConfetti(120);
+  }
+})();
+
+// ─── 3. Logo 5× click ─────────────────────────────────────────────────────────
+(function logoClickEasterEgg() {
+  const logo = document.querySelector(".aside .logo a");
+  if (!logo) return;
+
+  let clicks = 0;
+  let timer;
+
+  logo.addEventListener("click", (e) => {
+    e.preventDefault();
+    clicks++;
+    clearTimeout(timer);
+    timer = setTimeout(() => (clicks = 0), 1200);
+
+    if (clicks >= 5) {
+      clicks = 0;
+      showHireMeOverlay();
+    }
+  });
+
+  function showHireMeOverlay() {
+    if (document.getElementById("hire-me-overlay")) return;
+
+    const overlay = document.createElement("div");
+    overlay.id = "hire-me-overlay";
+    overlay.innerHTML = `
+      <div class="hire-me-box">
+        <div class="hire-me-emoji">🚀</div>
+        <h2 class="hire-me-title">HIRE ME!</h2>
+        <p class="hire-me-subtitle">Seriously though 🥺</p>
+        <p class="hire-me-sub2">Full Stack · DevOps · Cloud · Enthusiastic Human</p>
+        <a href="mailto:karapaanilkumar@gmail.com" class="hire-me-btn">
+          📧 Let's Talk
+        </a>
+        <button class="hire-me-close" id="hire-me-close">Maybe later</button>
+      </div>
+    `;
+    document.body.appendChild(overlay);
+    setTimeout(() => overlay.classList.add("hire-me-visible"), 10);
+    burstConfetti(80);
+
+    document.getElementById("hire-me-close").addEventListener("click", () => {
+      overlay.classList.remove("hire-me-visible");
+      setTimeout(() => overlay.remove(), 400);
+    });
+    overlay.addEventListener("click", (e) => {
+      if (e.target === overlay) {
+        overlay.classList.remove("hire-me-visible");
+        setTimeout(() => overlay.remove(), 400);
+      }
+    });
+  }
+})();
+
+// ─── 4. Idle message ──────────────────────────────────────────────────────────
+(function idleMessage() {
+  const IDLE_MS = 45000;
+  const MESSAGES = [
+    "👀 Still here? I like your dedication.",
+    "☕ Go grab a coffee — I'll still be here.",
+    "🤔 Thinking about reaching out?",
+    "🎯 Psst… the email link is right up top.",
+    "💡 Fun fact: This site runs on 0 frameworks. Just vibes.",
+  ];
+  let idleTimer;
+  let toast;
+  let msgIdx = 0;
+
+  function resetIdle() {
+    clearTimeout(idleTimer);
+    if (toast) {
+      toast.classList.remove("ee-toast-show");
+    }
+    idleTimer = setTimeout(showIdleMsg, IDLE_MS);
+  }
+
+  function showIdleMsg() {
+    if (document.hidden) return;
+    if (toast) toast.remove();
+    toast = document.createElement("div");
+    toast.className = "ee-toast ee-idle-toast";
+    toast.textContent = MESSAGES[msgIdx % MESSAGES.length];
+    msgIdx++;
+    document.body.appendChild(toast);
+    setTimeout(() => toast.classList.add("ee-toast-show"), 10);
+    setTimeout(() => {
+      toast.classList.remove("ee-toast-show");
+      setTimeout(() => { if (toast) toast.remove(); toast = null; }, 400);
+    }, 4500);
+  }
+
+  ["mousemove","keydown","scroll","click","touchstart"].forEach((ev) =>
+    document.addEventListener(ev, resetIdle, { passive: true })
+  );
+  resetIdle();
+})();
+
+// ─── 5. Secret word "hire" typed anywhere ─────────────────────────────────────
+(function secretWordEgg() {
+  const TARGET = "hire";
+  let buf = "";
+
+  document.addEventListener("keydown", (e) => {
+    if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") return;
+    buf = (buf + e.key).slice(-TARGET.length).toLowerCase();
+    if (buf === TARGET) {
+      buf = "";
+      flashHireGlow();
+    }
+  });
+
+  function flashHireGlow() {
+    const flash = document.createElement("div");
+    flash.className = "ee-hire-flash";
+    flash.textContent = "💼 Hiring? Let's connect!";
+    document.body.appendChild(flash);
+    setTimeout(() => flash.classList.add("ee-hire-flash-show"), 10);
+    setTimeout(() => {
+      flash.classList.remove("ee-hire-flash-show");
+      setTimeout(() => flash.remove(), 600);
+    }, 2200);
+  }
+})();
+
+// ─── Shared confetti helper ────────────────────────────────────────────────────
+function burstConfetti(count = 60) {
+  const colors = [
+    "#dfa70a","#ff6b6b","#4ecdc4","#45b7d1","#f9ca24",
+    "#6c5ce7","#fd79a8","#00b894","#e17055","#74b9ff",
+  ];
+  const cx = window.innerWidth / 2;
+  const cy = window.innerHeight / 2;
+
+  for (let i = 0; i < count; i++) {
+    const dot = document.createElement("div");
+    dot.className = "ee-confetti-dot";
+    const color = colors[Math.floor(Math.random() * colors.length)];
+    const angle = Math.random() * Math.PI * 2;
+    const dist  = 150 + Math.random() * 250;
+    const tx    = Math.cos(angle) * dist;
+    const ty    = Math.sin(angle) * dist;
+    const size  = 6 + Math.random() * 8;
+
+    Object.assign(dot.style, {
+      left: cx + "px",
+      top:  cy + "px",
+      width: size + "px",
+      height: size + "px",
+      background: color,
+      borderRadius: Math.random() > 0.5 ? "50%" : "2px",
+      "--tx": tx + "px",
+      "--ty": ty + "px",
+    });
+    document.body.appendChild(dot);
+    setTimeout(() => dot.remove(), 1400);
+  }
+}

--- a/scripts/nfl-calendar.js
+++ b/scripts/nfl-calendar.js
@@ -1,0 +1,283 @@
+/**
+ * NFL Team Calendar Picker
+ * Fetches real-time schedules from the ESPN public API (no key needed)
+ * and generates ICS files for any selected teams.
+ */
+document.addEventListener("DOMContentLoaded", () => {
+  // ─── Team roster with ESPN IDs ────────────────────────────────────────────
+  const NFL_TEAMS = [
+    { id: "22", name: "Arizona Cardinals",    abbr: "ARI", color: "#97233F", division: "NFC West"  },
+    { id: "1",  name: "Atlanta Falcons",      abbr: "ATL", color: "#A71930", division: "NFC South" },
+    { id: "33", name: "Baltimore Ravens",     abbr: "BAL", color: "#241773", division: "AFC North" },
+    { id: "2",  name: "Buffalo Bills",        abbr: "BUF", color: "#00338D", division: "AFC East"  },
+    { id: "29", name: "Carolina Panthers",    abbr: "CAR", color: "#0085CA", division: "NFC South" },
+    { id: "3",  name: "Chicago Bears",        abbr: "CHI", color: "#C83803", division: "NFC North" },
+    { id: "4",  name: "Cincinnati Bengals",   abbr: "CIN", color: "#FB4F14", division: "AFC North" },
+    { id: "5",  name: "Cleveland Browns",     abbr: "CLE", color: "#FF3C00", division: "AFC North" },
+    { id: "6",  name: "Dallas Cowboys",       abbr: "DAL", color: "#003594", division: "NFC East"  },
+    { id: "7",  name: "Denver Broncos",       abbr: "DEN", color: "#FB4F14", division: "AFC West"  },
+    { id: "8",  name: "Detroit Lions",        abbr: "DET", color: "#0076B6", division: "NFC North" },
+    { id: "9",  name: "Green Bay Packers",    abbr: "GB",  color: "#203731", division: "NFC North" },
+    { id: "34", name: "Houston Texans",       abbr: "HOU", color: "#03202F", division: "AFC South" },
+    { id: "11", name: "Indianapolis Colts",   abbr: "IND", color: "#002C5F", division: "AFC South" },
+    { id: "30", name: "Jacksonville Jaguars", abbr: "JAX", color: "#006778", division: "AFC South" },
+    { id: "12", name: "Kansas City Chiefs",   abbr: "KC",  color: "#E31837", division: "AFC West"  },
+    { id: "13", name: "Las Vegas Raiders",    abbr: "LV",  color: "#A5ACAF", division: "AFC West"  },
+    { id: "24", name: "Los Angeles Chargers", abbr: "LAC", color: "#0080C6", division: "AFC West"  },
+    { id: "14", name: "Los Angeles Rams",     abbr: "LAR", color: "#003594", division: "NFC West"  },
+    { id: "15", name: "Miami Dolphins",       abbr: "MIA", color: "#008E97", division: "AFC East"  },
+    { id: "16", name: "Minnesota Vikings",    abbr: "MIN", color: "#4F2683", division: "NFC North" },
+    { id: "17", name: "New England Patriots", abbr: "NE",  color: "#002244", division: "AFC East"  },
+    { id: "18", name: "New Orleans Saints",   abbr: "NO",  color: "#D3BC8D", division: "NFC South" },
+    { id: "19", name: "New York Giants",      abbr: "NYG", color: "#0B2265", division: "NFC East"  },
+    { id: "20", name: "New York Jets",        abbr: "NYJ", color: "#125740", division: "AFC East"  },
+    { id: "21", name: "Philadelphia Eagles",  abbr: "PHI", color: "#004C54", division: "NFC East"  },
+    { id: "23", name: "Pittsburgh Steelers",  abbr: "PIT", color: "#FFB612", division: "AFC North" },
+    { id: "25", name: "San Francisco 49ers",  abbr: "SF",  color: "#AA0000", division: "NFC West"  },
+    { id: "26", name: "Seattle Seahawks",     abbr: "SEA", color: "#002244", division: "NFC West"  },
+    { id: "27", name: "Tampa Bay Buccaneers", abbr: "TB",  color: "#D50A0A", division: "NFC South" },
+    { id: "10", name: "Tennessee Titans",     abbr: "TEN", color: "#4B92DB", division: "AFC South" },
+    { id: "28", name: "Washington Commanders",abbr: "WAS", color: "#5A1414", division: "NFC East"  },
+  ];
+
+  const DIVISIONS = [
+    "AFC East","AFC North","AFC South","AFC West",
+    "NFC East","NFC North","NFC South","NFC West",
+  ];
+
+  // ─── DOM refs ─────────────────────────────────────────────────────────────
+  const grid          = document.getElementById("nfl-teams-grid");
+  const downloadBtn   = document.getElementById("nfl-download-ics");
+  const clearBtn      = document.getElementById("nfl-clear-btn");
+  const selectAllBtn  = document.getElementById("nfl-select-all-btn");
+  const statusEl      = document.getElementById("nfl-status");
+  const countLabel    = document.getElementById("nfl-selected-count");
+  const importGuide   = document.getElementById("nfl-import-guide");
+
+  if (!grid) return;
+
+  // ─── State ────────────────────────────────────────────────────────────────
+  const selected = new Set();
+
+  // ─── Render team grid grouped by division ─────────────────────────────────
+  DIVISIONS.forEach((division) => {
+    const teamsInDiv = NFL_TEAMS.filter((t) => t.division === division);
+
+    const divWrapper = document.createElement("div");
+    divWrapper.className = "nfl-division-group";
+
+    const divTitle = document.createElement("h4");
+    divTitle.className = "nfl-division-title";
+    divTitle.textContent = division;
+    divWrapper.appendChild(divTitle);
+
+    const teamRow = document.createElement("div");
+    teamRow.className = "nfl-division-teams";
+
+    teamsInDiv.forEach((team) => {
+      const card = document.createElement("button");
+      card.className = "nfl-team-card";
+      card.dataset.id = team.id;
+      card.style.setProperty("--tc", team.color);
+      card.title = team.name;
+      card.innerHTML = `
+        <span class="nfl-check-icon"><i class="fas fa-check"></i></span>
+        <img
+          src="https://a.espncdn.com/i/teamlogos/nfl/500/${team.abbr.toLowerCase()}.png"
+          alt="${team.name} logo"
+          class="nfl-logo"
+          loading="lazy"
+          onerror="this.src=''"
+        />
+        <span class="nfl-abbr">${team.abbr}</span>
+      `;
+      card.addEventListener("click", () => toggleTeam(team, card));
+      teamRow.appendChild(card);
+    });
+
+    divWrapper.appendChild(teamRow);
+    grid.appendChild(divWrapper);
+  });
+
+  // ─── Toggle selection ─────────────────────────────────────────────────────
+  function toggleTeam(team, card) {
+    if (selected.has(team.id)) {
+      selected.delete(team.id);
+      card.classList.remove("nfl-selected");
+    } else {
+      selected.add(team.id);
+      card.classList.add("nfl-selected");
+    }
+    refreshUI();
+  }
+
+  function refreshUI() {
+    const n = selected.size;
+    countLabel.textContent =
+      n === 0 ? "No teams selected" : `${n} team${n !== 1 ? "s" : ""} selected`;
+    downloadBtn.disabled = n === 0;
+    if (statusEl) statusEl.textContent = "";
+    if (importGuide) importGuide.hidden = true;
+  }
+
+  // ─── Select all / clear ───────────────────────────────────────────────────
+  selectAllBtn?.addEventListener("click", () => {
+    NFL_TEAMS.forEach((team) => {
+      selected.add(team.id);
+      grid
+        .querySelector(`[data-id="${team.id}"]`)
+        ?.classList.add("nfl-selected");
+    });
+    refreshUI();
+  });
+
+  function clearAll() {
+    selected.clear();
+    grid
+      .querySelectorAll(".nfl-team-card.nfl-selected")
+      .forEach((c) => c.classList.remove("nfl-selected"));
+    refreshUI();
+  }
+
+  clearBtn?.addEventListener("click", clearAll);
+  document.getElementById("nfl-clear-btn-2")?.addEventListener("click", clearAll);
+
+  // ─── ESPN API helpers ─────────────────────────────────────────────────────
+  async function fetchTeamSchedule(teamId) {
+    const url = `https://site.api.espn.com/apis/site/v2/sports/football/nfl/teams/${teamId}/schedule`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`ESPN API ${res.status} for team ${teamId}`);
+    return res.json();
+  }
+
+  function parseGames(data, teamName) {
+    return (data.events || [])
+      .filter((e) => e.competitions?.[0])
+      .map((e) => {
+        const comp = e.competitions[0];
+        const home = comp.competitors?.find((c) => c.homeAway === "home");
+        const away = comp.competitors?.find((c) => c.homeAway === "away");
+        const venue = comp.venue || {};
+        const homeAbbr = home?.team?.abbreviation ?? "HOME";
+        const awayAbbr = away?.team?.abbreviation ?? "AWAY";
+        return {
+          uid: e.id,
+          start: new Date(e.date),
+          summary: `🏈 ${awayAbbr} @ ${homeAbbr}`,
+          description: `NFL ${e.season?.year ?? ""} — ${teamName}\n${e.name ?? ""}`,
+          location: [venue.fullName, venue.address?.city, venue.address?.state]
+            .filter(Boolean)
+            .join(", "),
+        };
+      });
+  }
+
+  // ─── ICS builder ──────────────────────────────────────────────────────────
+  function toUTC(date) {
+    return date.toISOString().replace(/[-:.]/g, "").slice(0, 15) + "Z";
+  }
+
+  function buildICS(games) {
+    const lines = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//NFL Schedule 2025//AK Portfolio//EN",
+      "CALSCALE:GREGORIAN",
+      "METHOD:PUBLISH",
+      "X-WR-CALNAME:NFL Schedule 2025",
+      "X-WR-TIMEZONE:America/New_York",
+    ];
+
+    games.forEach((g) => {
+      const end = new Date(g.start.getTime() + 3 * 60 * 60 * 1000);
+      lines.push(
+        "BEGIN:VEVENT",
+        `UID:${g.uid}@nfl-ak-portfolio`,
+        `DTSTART:${toUTC(g.start)}`,
+        `DTEND:${toUTC(end)}`,
+        `SUMMARY:${g.summary}`,
+        `DESCRIPTION:${g.description.replace(/\n/g, "\\n")}`,
+        `LOCATION:${g.location}`,
+        "END:VEVENT"
+      );
+    });
+
+    lines.push("END:VCALENDAR");
+    return lines.join("\r\n");
+  }
+
+  function triggerDownload(content, filename) {
+    const blob = new Blob([content], { type: "text/calendar;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = Object.assign(document.createElement("a"), {
+      href: url,
+      download: filename,
+    });
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+
+  function setStatus(msg, type = "info") {
+    if (!statusEl) return;
+    statusEl.textContent = msg;
+    statusEl.className = `nfl-status-msg nfl-status-${type}`;
+  }
+
+  // ─── Download handler ─────────────────────────────────────────────────────
+  downloadBtn?.addEventListener("click", async () => {
+    const teamIds = [...selected];
+    downloadBtn.disabled = true;
+    downloadBtn.innerHTML = `<i class="fas fa-spinner fa-spin"></i> Fetching from ESPN…`;
+    setStatus("⏳ Fetching live schedule data from ESPN…", "loading");
+
+    try {
+      const results = await Promise.all(
+        teamIds.map((id) => {
+          const team = NFL_TEAMS.find((t) => t.id === id);
+          return fetchTeamSchedule(id).then((data) =>
+            parseGames(data, team.name)
+          );
+        })
+      );
+
+      // Deduplicate by uid (shared games appear in both teams' schedules)
+      const seen = new Set();
+      const unique = results
+        .flat()
+        .filter((g) => {
+          if (seen.has(g.uid)) return false;
+          seen.add(g.uid);
+          return true;
+        })
+        .sort((a, b) => a.start - b.start);
+
+      if (unique.length === 0) {
+        setStatus("No upcoming games found for the selected teams.", "error");
+        return;
+      }
+
+      const ics = buildICS(unique);
+      const teamNames = teamIds
+        .map((id) => NFL_TEAMS.find((t) => t.id === id)?.abbr)
+        .join("-");
+      triggerDownload(ics, `nfl-schedule-${teamNames}-2025.ics`);
+
+      setStatus(
+        `✅ Downloaded ${unique.length} game${unique.length !== 1 ? "s" : ""} for ${teamIds.length} team${teamIds.length !== 1 ? "s" : ""}!`,
+        "success"
+      );
+      if (importGuide) importGuide.hidden = false;
+    } catch (err) {
+      console.error("NFL schedule fetch error:", err);
+      setStatus("❌ Could not fetch schedules from ESPN. Try again shortly.", "error");
+    } finally {
+      downloadBtn.disabled = false;
+      downloadBtn.innerHTML = `<i class="fas fa-download"></i> Download .ics`;
+      downloadBtn.disabled = selected.size === 0;
+    }
+  });
+
+  refreshUI();
+});

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -40,6 +40,98 @@ document.addEventListener("DOMContentLoaded", function () {
   window.addEventListener("scroll", onScroll, { passive: true });
 });
 
+// ─── 3D tilt on project cards ──────────────────────────────────────────────
+// Runs after projects are injected into the DOM via MutationObserver
+(function initCardTilt() {
+  const MAX_TILT = 7;
+
+  function applyTilt(card) {
+    card.addEventListener("mousemove", (e) => {
+      const r   = card.getBoundingClientRect();
+      const x   = e.clientX - r.left;
+      const y   = e.clientY - r.top;
+      const rx  = ((y / r.height) - 0.5) * -MAX_TILT * 2;
+      const ry  = ((x / r.width)  - 0.5) *  MAX_TILT * 2;
+      card.style.transform = `translateY(-10px) perspective(900px) rotateX(${rx}deg) rotateY(${ry}deg)`;
+    });
+    card.addEventListener("mouseleave", () => {
+      card.style.transform = "";
+    });
+  }
+
+  // Apply to existing cards and any added later
+  function attachAll() {
+    document.querySelectorAll(".project-card:not([data-tilt])").forEach((c) => {
+      c.dataset.tilt = "1";
+      applyTilt(c);
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    attachAll();
+    const grid = document.getElementById("projects-grid");
+    if (grid) {
+      new MutationObserver(attachAll).observe(grid, { childList: true });
+    }
+  });
+})();
+
+// ─── IntersectionObserver scroll-reveal ────────────────────────────────────
+document.addEventListener("DOMContentLoaded", () => {
+  const revealEls = document.querySelectorAll(
+    ".section, .skill-bookshelf-section, .about_content, .crl_card, .nfl-calendar-section"
+  );
+  if (!("IntersectionObserver" in window)) {
+    revealEls.forEach((el) => el.classList.add("is-visible"));
+    return;
+  }
+  const io = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((en) => {
+        if (en.isIntersecting) {
+          en.target.classList.add("is-visible");
+          io.unobserve(en.target);
+        }
+      });
+    },
+    { threshold: 0.08 }
+  );
+  revealEls.forEach((el) => {
+    el.classList.add("reveal");
+    io.observe(el);
+  });
+});
+
+// ─── Count-up animation for years of experience ────────────────────────────
+document.addEventListener("DOMContentLoaded", () => {
+  const el = document.getElementById("years_experience");
+  if (!el) return;
+
+  // Wait until experienceCal.js has set the text
+  const waitForText = setInterval(() => {
+    const raw = el.textContent;
+    const match = raw.match(/([\d.]+)/);
+    if (!match) return;
+    clearInterval(waitForText);
+
+    const target = parseFloat(match[1]);
+    const prefix = raw.slice(0, raw.indexOf(match[1]));
+    const suffix = raw.slice(raw.indexOf(match[1]) + match[1].length);
+    let start = null;
+    const DURATION = 1400;
+
+    function step(ts) {
+      if (!start) start = ts;
+      const progress = Math.min((ts - start) / DURATION, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      el.textContent = prefix + (eased * target).toFixed(1) + suffix;
+      if (progress < 1) requestAnimationFrame(step);
+    }
+    requestAnimationFrame(step);
+  }, 100);
+});
+
+// ─── Typed.js ───────────────────────────────────────────────────────────────
 document.addEventListener("DOMContentLoaded", function () {
   const typingElement = document.querySelector(".typing");
 

--- a/scripts/skills.js
+++ b/scripts/skills.js
@@ -132,6 +132,10 @@ document.addEventListener("DOMContentLoaded", () => {
       book.style.animationDelay = `${totalBookIndex * 0.05}s`;
 
       book.addEventListener("mouseover", () => {
+        // flash the panel so the new text feels alive
+        descriptionPanel.classList.remove("panel-pop");
+        void descriptionPanel.offsetWidth; // reflow to restart animation
+        descriptionPanel.classList.add("panel-pop");
         descriptionPanel.innerHTML = `<span class="skill-name">${skill.name}</span>${skill.desc}`;
       });
 

--- a/scripts/updatedProjects.js
+++ b/scripts/updatedProjects.js
@@ -88,11 +88,15 @@ document.addEventListener("DOMContentLoaded", () => {
         .map((tag) => `<span class="card-tag">${tag}</span>`)
         .join("");
 
+      const isPinned = project.tags.includes("Pinned");
+      if (isPinned) card.classList.add("is-pinned");
+
       const quickLookBtn = project.links.live
-        ? `<button class="card-btn btn-primary btn-quick-look" data-url="${project.links.live}" data-title="${project.title}">Quick Look</button>`
+        ? `<button class="card-btn btn-primary btn-quick-look" data-url="${project.links.live}" data-title="${project.title}"><i class="fas fa-eye" style="margin-right:0.35rem;font-size:0.85em;"></i>Quick Look</button>`
         : "";
 
       card.innerHTML = `
+        ${isPinned ? '<span class="card-pinned-ribbon" title="Featured project">📌</span>' : ""}
         <div class="card-image-container">
           <img src="${project.image}" alt="${project.title} Preview" loading="lazy">
         </div>
@@ -103,7 +107,7 @@ document.addEventListener("DOMContentLoaded", () => {
             ${tagsHtml}
           </div>
           <div class="card-links">
-            <a href="${project.links.github}" class="card-btn btn-secondary" target="_blank" rel="noopener noreferrer">View Code</a>
+            <a href="${project.links.github}" class="card-btn btn-secondary" target="_blank" rel="noopener noreferrer"><i class="fab fa-github" style="margin-right:0.35rem;"></i>View Code</a>
             ${quickLookBtn}
           </div>
         </div>

--- a/scripts/visitor-tracker.js
+++ b/scripts/visitor-tracker.js
@@ -1,0 +1,83 @@
+/**
+ * Visitor Tracker
+ * - Tracks per-device visit count & first-visit date via localStorage
+ * - Attempts a global hit count via CountAPI (free, no auth)
+ * - Renders a subtle badge in the footer area
+ */
+(function initVisitorTracker() {
+  // ── Per-device stats ──────────────────────────────────────────────────────
+  const VISIT_KEY       = "ak_portfolio_visits";
+  const FIRST_VISIT_KEY = "ak_portfolio_first_visit";
+
+  const now       = new Date();
+  const firstVisit = localStorage.getItem(FIRST_VISIT_KEY) || now.toISOString();
+  const visits     = parseInt(localStorage.getItem(VISIT_KEY) || "0", 10) + 1;
+
+  localStorage.setItem(VISIT_KEY, visits);
+  if (!localStorage.getItem(FIRST_VISIT_KEY)) {
+    localStorage.setItem(FIRST_VISIT_KEY, firstVisit);
+  }
+
+  const firstDate = new Date(firstVisit);
+  const firstStr  = firstDate.toLocaleDateString("en-US", {
+    month: "short", day: "numeric", year: "numeric",
+  });
+
+  // ── Inject badge ──────────────────────────────────────────────────────────
+  const badge = document.createElement("div");
+  badge.id = "visitor-badge";
+  badge.className = "visitor-badge";
+  badge.innerHTML = `
+    <span class="vb-pulse"></span>
+    <span class="vb-text">
+      Your visit <strong>#${visits}</strong>
+      <span class="vb-sep">·</span>
+      <span class="vb-global" id="vb-global" title="Total page views">
+        <i class="fas fa-globe" style="font-size:0.75rem;margin-right:2px;"></i>
+        <span id="vb-global-count">…</span> visitors
+      </span>
+    </span>
+  `;
+  document.body.appendChild(badge);
+
+  // First-visit tooltip
+  if (visits === 1) {
+    const tip = document.createElement("div");
+    tip.className = "vb-welcome-tip";
+    tip.textContent = "👋 Welcome! First time here?";
+    document.body.appendChild(tip);
+    setTimeout(() => tip.classList.add("vb-welcome-show"), 200);
+    setTimeout(() => {
+      tip.classList.remove("vb-welcome-show");
+      setTimeout(() => tip.remove(), 500);
+    }, 4000);
+  }
+
+  // ── Global counter via CountAPI ───────────────────────────────────────────
+  // Free tier — namespace + key uniquely identify this counter
+  const globalCountEl = document.getElementById("vb-global-count");
+  fetch("https://api.countapi.xyz/hit/ak-portfolio-anil-kumar-2025/visitors")
+    .then((r) => r.json())
+    .then((data) => {
+      if (data?.value && globalCountEl) {
+        globalCountEl.textContent = data.value.toLocaleString();
+      }
+    })
+    .catch(() => {
+      // silently fall back — don't show broken UI
+      const globalEl = document.getElementById("vb-global");
+      if (globalEl) globalEl.style.display = "none";
+    });
+
+  // ── Hide after scroll (unobtrusive) ──────────────────────────────────────
+  let hidden = false;
+  window.addEventListener("scroll", () => {
+    if (window.scrollY > 300 && !hidden) {
+      badge.classList.add("vb-faded");
+      hidden = true;
+    } else if (window.scrollY <= 100 && hidden) {
+      badge.classList.remove("vb-faded");
+      hidden = false;
+    }
+  }, { passive: true });
+})();

--- a/styles/about_styles.css
+++ b/styles/about_styles.css
@@ -16,12 +16,12 @@
 .name {
   display: inline-block;
   font-weight: 900;
+  font-size: 3rem;
   position: relative;
   color: #ff8c00;
-  cursor: pointer;
-  transition: all 0.3s ease;
-
   cursor: vertical-text;
+  transition: all 0.3s ease;
+  letter-spacing: -0.02em;
 }
 
 .name::before {

--- a/styles/animations.css
+++ b/styles/animations.css
@@ -1,0 +1,358 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   animations.css — cursor, particles, section dots, ripple, mobile polish
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* ─── Reduced motion: disable everything ─────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .cursor-dot, .cursor-ring { display: none !important; }
+  #hero-particles { display: none !important; }
+  .ripple { display: none !important; }
+  .tl-slide { transition: none !important; }
+}
+
+/* ─── Custom cursor (desktop/fine-pointer only) ───────────────────────────── */
+@media (pointer: fine) {
+  body { cursor: none; }
+  a, button, [role="button"], .card-btn, .filter-btn,
+  .project-card, .nav li a, input, .style-switcher-toggler {
+    cursor: none;
+  }
+}
+
+.cursor-dot {
+  position: fixed;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--skin-color);
+  pointer-events: none;
+  z-index: 99999;
+  top: 0; left: 0;
+  transform: translate(-50%, -50%);
+  transition: width 0.18s ease, height 0.18s ease, opacity 0.3s ease;
+  will-change: transform;
+}
+
+.cursor-ring {
+  position: fixed;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 2px solid var(--skin-color);
+  pointer-events: none;
+  z-index: 99998;
+  top: 0; left: 0;
+  transform: translate(-50%, -50%);
+  transition: width 0.25s ease, height 0.25s ease, border-color 0.2s ease, opacity 0.3s ease;
+  opacity: 0.55;
+  will-change: transform;
+}
+
+.cursor-dot.cur-hover  { width: 14px; height: 14px; }
+.cursor-ring.cur-hover { width: 56px; height: 56px; opacity: 0.85; }
+
+.cursor-dot.cur-gone, .cursor-ring.cur-gone { opacity: 0; }
+
+/* Hide on touch devices */
+@media (pointer: coarse) {
+  .cursor-dot, .cursor-ring { display: none !important; }
+}
+
+/* ─── Hero particle canvas ────────────────────────────────────────────────── */
+#hero-particles {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/* ─── Section navigation dots ────────────────────────────────────────────── */
+.section-dots {
+  position: fixed;
+  right: 1.1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  z-index: 800;
+}
+
+.section-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: transparent;
+  border: 2px solid var(--text-black-700);
+  cursor: pointer;
+  opacity: 0.45;
+  transition: all 0.28s cubic-bezier(0.34, 1.56, 0.64, 1);
+  position: relative;
+}
+
+.section-dot::after {
+  content: attr(data-label);
+  position: absolute;
+  right: calc(100% + 10px);
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--bg-black-100);
+  color: var(--text-black-900);
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.2rem 0.6rem;
+  border-radius: 6px;
+  border: 1px solid var(--bg-black-50);
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.section-dot:hover::after { opacity: 1; }
+
+.section-dot:hover {
+  opacity: 0.85;
+  border-color: var(--skin-color);
+}
+
+.section-dot.sd-active {
+  background: var(--skin-color);
+  border-color: var(--skin-color);
+  transform: scale(1.6);
+  opacity: 1;
+  box-shadow: 0 0 10px var(--skin-color);
+}
+
+@media (max-width: 1260px) { .section-dots { display: none; } }
+
+/* ─── Button click ripple ─────────────────────────────────────────────────── */
+.btn, .card-btn, .filter-btn, .eagles-download-btn, .nfl-btn, .card-btn {
+  position: relative;
+  overflow: hidden;
+}
+
+.ripple {
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.3);
+  transform: scale(0);
+  animation: ripple-out 0.55s linear forwards;
+  pointer-events: none;
+}
+
+@keyframes ripple-out {
+  to { transform: scale(5); opacity: 0; }
+}
+
+/* ─── Timeline item slide-in ─────────────────────────────────────────────── */
+.timeline_item {
+  opacity: 0;
+  transform: translateX(-18px);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+}
+
+.timeline_item.tl-visible {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+/* stagger */
+.timeline_item:nth-child(1) { transition-delay: 0.05s; }
+.timeline_item:nth-child(2) { transition-delay: 0.15s; }
+.timeline_item:nth-child(3) { transition-delay: 0.25s; }
+.timeline_item:nth-child(4) { transition-delay: 0.35s; }
+
+/* ─── Timeline dot pop ───────────────────────────────────────────────────── */
+.timeline_item.tl-visible .circle_dot {
+  animation: dot-pop 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+@keyframes dot-pop {
+  from { transform: scale(0); }
+  to   { transform: scale(1); }
+}
+
+/* ─── CRL stat count-up highlight ───────────────────────────────────────── */
+.crl_value.crl-counting {
+  color: var(--skin-color);
+}
+
+/* ─── Eagles card sparkle on button ready ────────────────────────────────── */
+.eagles-download-btn:not(:disabled) {
+  animation: btn-ready-pulse 2.5s ease-in-out 1;
+}
+
+@keyframes btn-ready-pulse {
+  0%   { box-shadow: 0 4px 15px rgba(0, 76, 84, 0.35); }
+  50%  { box-shadow: 0 4px 30px rgba(0, 76, 84, 0.7), 0 0 0 4px rgba(0, 76, 84, 0.15); }
+  100% { box-shadow: 0 4px 15px rgba(0, 76, 84, 0.35); }
+}
+
+/* ─── Glow scan line on section titles ──────────────────────────────────── */
+.section_title {
+  position: relative;
+  overflow: hidden;
+}
+
+.section_title::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 50%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.05), transparent);
+  animation: title-scan 4s ease-in-out infinite;
+  pointer-events: none;
+}
+
+@keyframes title-scan {
+  0%   { left: -50%; }
+  100% { left: 150%; }
+}
+
+/* ─── Filter button group entrance ──────────────────────────────────────── */
+.filter-btn {
+  animation: filter-pop 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.filter-btn:nth-child(1) { animation-delay: 0.05s; }
+.filter-btn:nth-child(2) { animation-delay: 0.10s; }
+.filter-btn:nth-child(3) { animation-delay: 0.15s; }
+.filter-btn:nth-child(4) { animation-delay: 0.20s; }
+.filter-btn:nth-child(5) { animation-delay: 0.25s; }
+.filter-btn:nth-child(6) { animation-delay: 0.30s; }
+.filter-btn:nth-child(7) { animation-delay: 0.35s; }
+
+@keyframes filter-pop {
+  from { opacity: 0; transform: scale(0.75) translateY(8px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+/* ─── Active filter button: animated border ──────────────────────────────── */
+.filter-btn.active {
+  background: var(--skin-color);
+  color: var(--text-black-900);
+  animation: none;
+  box-shadow: 0 0 0 3px rgba(223, 167, 10, 0.2), 0 4px 14px rgba(0,0,0,0.25);
+}
+
+/* ─── Project card entrance stagger ────────────────────────────────────── */
+@keyframes card-in {
+  from { opacity: 0; transform: translateY(24px) scale(0.97); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* ─── Magnetic button wrapper ────────────────────────────────────────────── */
+.mag-wrap {
+  display: inline-block;
+  will-change: transform;
+  transition: transform 0.35s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+/* ─── Skills shelf item hover pop ───────────────────────────────────────── */
+.shelf_item {
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.25s ease;
+}
+
+.shelf_item:hover {
+  transform: translateY(-6px) scale(1.06);
+  box-shadow: 0 8px 20px rgba(0,0,0,0.25);
+  z-index: 2;
+}
+
+/* ─── Mobile improvements ────────────────────────────────────────────────── */
+@media (max-width: 1260px) {
+  .main_content {
+    padding-top: 9dvh;
+  }
+}
+
+@media (max-width: 860px) {
+  /* Bigger touch targets */
+  .card-btn     { min-height: 48px; }
+  .filter-btn   { min-height: 40px; padding: 0.5rem 1rem; }
+  .nav li a     { min-height: 44px; }
+
+  /* Hero */
+  .need_job {
+    min-height: unset;
+    padding: 2.5rem 1rem 3rem;
+  }
+
+  /* Project card stagger resets on mobile to avoid long waits */
+  .project-card { animation-delay: 0s !important; }
+
+  /* Eagles card */
+  .eagles-download-btn { font-size: 0.9rem; padding: 0.75rem 1.1rem; }
+  .eagles-cal-shortcuts .eagles-shortcut-row { flex-direction: column; }
+
+  /* NFL team grid */
+  .nfl-teams-grid { grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)) !important; }
+}
+
+@media (max-width: 600px) {
+  /* Smaller filter row, horizontal scroll */
+  .filter-group { flex-wrap: nowrap; overflow-x: auto; padding-bottom: 0.4rem; }
+  .filter-group::-webkit-scrollbar { height: 3px; }
+  .filter-group::-webkit-scrollbar-thumb { background: var(--skin-color); border-radius: 99px; }
+  .filter-btn { white-space: nowrap; flex-shrink: 0; }
+
+  /* Hero name */
+  .asking_job h1 { font-size: clamp(1.5rem, 7vw, 2rem); }
+
+  /* Better card layout: single column on very small screens */
+  .projects-grid { grid-template-columns: 1fr !important; }
+
+  /* Profession badges: wrap nicely */
+  .profession-badges { gap: 0.3rem; }
+  .prof-badge { font-size: 0.7rem; padding: 0.2rem 0.5rem; }
+}
+
+/* ─── Aside sidebar — glassmorphism touch on desktop ───────────────────── */
+@media (min-width: 1261px) {
+  .aside {
+    background: rgba(var(--bg-black-100-raw, 253, 249, 255), 0.92);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-right: 1px solid rgba(255,255,255,0.06);
+  }
+
+  body.dark .aside {
+    background: rgba(34, 34, 34, 0.92);
+  }
+}
+
+/* ─── Scroll progress bar — gradient upgrade ────────────────────────────── */
+.scroll_watcher {
+  background: linear-gradient(90deg, var(--skin-color), #6c5ce7, #fd79a8) !important;
+  height: 3px;
+}
+
+/* ─── Soft glow on hovered social links ─────────────────────────────────── */
+.aside .aside_links a:hover {
+  text-shadow: 0 0 12px var(--skin-color);
+}
+
+/* ─── Skill description panel entrance ──────────────────────────────────── */
+.skill-description-panel {
+  animation: panel-in 0.4s ease both;
+}
+
+@keyframes panel-in {
+  from { opacity: 0; transform: translateX(8px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+/* ─── CRL card stats grid responsive ────────────────────────────────────── */
+@media (max-width: 600px) {
+  .crl_stats_grid {
+    grid-template-columns: 1fr 1fr !important;
+  }
+  .crl_stat_item:last-child {
+    grid-column: 1 / -1;
+  }
+}

--- a/styles/cryforhelp.css
+++ b/styles/cryforhelp.css
@@ -1,18 +1,78 @@
 .need_job {
-  padding-inline: 0.5rem;
+  padding-inline: 1.5rem;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-
-  margin-top: 10dvh;
+  gap: 2.25rem;
+  padding-top: 10dvh;
+  padding-bottom: 4rem;
 }
 
-.need_job h1 {
-  font-size: 2rem;
-  /* font-style: italic; */
-  cursor: help;
+/* h1 is now handled by fun-ui.css gradient, no override needed */
+.need_job h1 { cursor: help; }
+
+/* ── "Developers!" chant row ── */
+.cry_for_help {
+  position: relative;
+  display: inline-block;
 }
 
+.cry_for_help h3 {
+  font-size: 1.2rem !important;
+  color: var(--text-black-700);
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.cry_for_help h3:hover { color: var(--skin-color); }
+
+/* blinking cursor after the chant */
+.cry_for_help h3::after {
+  content: "▋";
+  color: var(--skin-color);
+  animation: cursor-blink 1.1s step-end infinite;
+  margin-left: 2px;
+}
+
+@keyframes cursor-blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
+}
+
+.cry_for_help img { max-width: 40dvw; }
+
+/* ── Steve Ballmer popup ── */
+#image-popup {
+  display: none;
+  position: absolute;
+  top: 100%;
+  right: 50%;
+  transform: translateX(50%);
+  margin-top: 10px;
+  border-radius: 12px;
+  padding: 12px;
+  background: #0a0a0a;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  z-index: 10;
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+#image-popup p {
+  text-align: center;
+  font-size: 0.8rem;
+  color: #aaa;
+  margin: 0;
+  padding: 6px 0 0;
+}
+
+.cry_for_help #hover-trigger:hover + #image-popup {
+  display: block;
+  opacity: 0.95;
+  transform: translateX(120%) scale(1.04);
+}
+
+/* ── Heartbeat ── */
 .white_heart {
   animation: beat 0.7s infinite;
   display: inline-block;
@@ -20,45 +80,6 @@
 }
 
 @keyframes beat {
-  0%,
-  100% {
-    transform: scale(1.2);
-  }
-  50% {
-    transform: scale(1);
-  }
-}
-
-.cry_for_help {
-  position: relative;
-  display: inline-block;
-}
-
-.cry_for_help img {
-  max-width: 40dvw;
-  /* max-height: 10vh; */
-}
-
-#image-popup {
-  display: none;
-  position: absolute;
-  /* max-width: 80dvw; */
-  top: 100%;
-  right: 50%;
-  transform: translateX(50%);
-  margin-top: 10px;
-
-  border-radius: 8px;
-  padding: 10px;
-  background-color: black;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-  z-index: 10;
-  transition: transform 0.3s ease, opacity 0.3s ease;
-  opacity: 0;
-}
-
-.cry_for_help #hover-trigger:hover + #image-popup {
-  display: block;
-  opacity: 0.9;
-  transform: translateX(120%) scale(1.05);
+  0%, 100% { transform: scale(1.2); }
+  50%       { transform: scale(1);   }
 }

--- a/styles/eagles-form.css
+++ b/styles/eagles-form.css
@@ -298,6 +298,254 @@
 
 .eagles-import-guide li { color: var(--text-black-700); }
 
+/* ─── Step guide ──────────────────────────────────────────────────────── */
+.eagles-steps {
+  list-style: none;
+  margin: 0 0 1.25rem 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.eagles-step {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  transition: background 0.3s ease, border-color 0.3s ease;
+  opacity: 0.55;
+}
+
+.eagles-step.active {
+  opacity: 1;
+  border-color: rgba(0, 76, 84, 0.4);
+  background: rgba(0, 76, 84, 0.08);
+}
+
+.eagles-step.completed {
+  opacity: 1;
+  border-color: rgba(40, 167, 69, 0.35);
+  background: rgba(40, 167, 69, 0.07);
+}
+
+.estep-num {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1.5px solid rgba(255, 255, 255, 0.18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.78rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  color: var(--text-black-700);
+  transition: background 0.3s, border-color 0.3s;
+}
+
+.eagles-step.active .estep-num {
+  background: var(--eagles-green);
+  border-color: var(--eagles-green);
+  color: #fff;
+}
+
+.eagles-step.completed .estep-num {
+  background: #28a745;
+  border-color: #28a745;
+  color: #fff;
+}
+
+.estep-label {
+  flex: 1;
+  font-size: 0.88rem;
+  color: var(--text-black-700);
+}
+
+.eagles-step.active .estep-label,
+.eagles-step.completed .estep-label {
+  color: var(--text-black-900);
+}
+
+.estep-check {
+  font-size: 0.8rem;
+  color: #28a745;
+  opacity: 0;
+  transform: scale(0.5);
+  transition: opacity 0.35s ease, transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.eagles-step.completed .estep-check {
+  opacity: 1;
+  transform: scale(1);
+}
+
+/* ─── Download CTA button ─────────────────────────────────────────────── */
+.eagles-cta-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.eagles-download-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: linear-gradient(135deg, var(--eagles-green) 0%, #00737e 100%);
+  color: #fff;
+  font-family: "Poppins", sans-serif;
+  font-size: 0.97rem;
+  font-weight: 700;
+  padding: 0.8rem 1.5rem;
+  border-radius: 12px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 15px rgba(0, 76, 84, 0.35);
+  width: 100%;
+  text-align: left;
+}
+
+.eagles-download-btn:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0, 76, 84, 0.5);
+  filter: brightness(1.1);
+}
+
+.eagles-download-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.eagles-dl-left {
+  position: relative;
+  width: 1.3rem;
+  height: 1.3rem;
+  flex-shrink: 0;
+}
+
+.eagles-dl-spinner,
+.eagles-dl-icon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 1.1rem;
+}
+
+/* Spinner visible by default (pre-fetch in progress on load) */
+.eagles-dl-spinner { display: block; }
+.eagles-dl-icon    { display: none; }
+
+.eagles-dl-center {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.3;
+}
+
+.eagles-game-count {
+  font-size: 0.72rem;
+  font-weight: 600;
+  opacity: 0.75;
+  letter-spacing: 0.02em;
+}
+
+.eagles-cta-note {
+  font-size: 0.76rem !important;
+  color: var(--text-black-700);
+  opacity: 0.75;
+  margin: 0;
+  padding: 0;
+}
+
+/* ─── Status message ──────────────────────────────────────────────────── */
+.eagles-status-msg {
+  font-size: 0.87rem;
+  font-weight: 500;
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  transition: all 0.3s ease;
+  width: 100%;
+}
+
+.eagles-status-msg.status-loading { color: var(--text-black-700); }
+
+.eagles-status-msg.status-success {
+  color: #28a745;
+  background: rgba(40, 167, 69, 0.1);
+  border: 1px solid rgba(40, 167, 69, 0.3);
+}
+
+.eagles-status-msg.status-error {
+  color: #dc3545;
+  background: rgba(220, 53, 69, 0.1);
+  border: 1px solid rgba(220, 53, 69, 0.3);
+}
+
+/* ─── Calendar shortcuts panel ────────────────────────────────────────── */
+.eagles-cal-shortcuts {
+  background: rgba(0, 76, 84, 0.09);
+  border: 1px solid rgba(0, 76, 84, 0.3);
+  border-radius: 10px;
+  padding: 0.9rem 1rem;
+  margin-bottom: 0.5rem;
+  animation: shortcuts-in 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+@keyframes shortcuts-in {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.eagles-shortcuts-heading {
+  font-size: 0.82rem !important;
+  font-weight: 700;
+  color: var(--text-black-900);
+  margin: 0 0 0.6rem 0 !important;
+  padding: 0 !important;
+}
+
+.eagles-shortcut-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.eagles-shortcut-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-black-900);
+  text-decoration: none;
+  transition: all 0.2s ease;
+  cursor: pointer;
+}
+
+a.eagles-shortcut-btn:hover {
+  background: rgba(0, 76, 84, 0.2);
+  border-color: var(--eagles-green);
+  color: #fff;
+  transform: translateY(-1px);
+}
+
+.eagles-shortcut-static {
+  cursor: default;
+  opacity: 0.75;
+}
+
 /* ─── Divider between primary and email path ──────────────────────────── */
 .eagles-divider {
   display: flex;

--- a/styles/eagles-form.css
+++ b/styles/eagles-form.css
@@ -201,3 +201,122 @@
   color: #dc3545;
   border: 1px solid #dc3545;
 }
+
+/* ─── Direct ICS Download (primary path) ─────────────────────────────── */
+.eagles-direct-download {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.eagles-direct-label {
+  font-size: 0.9rem !important;
+  color: var(--text-black-700);
+  padding-bottom: 0;
+  margin: 0;
+}
+
+.eagles-ics-btn {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--eagles-green);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.95rem;
+  padding: 0.7rem 1.4rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+
+.eagles-ics-btn:hover:not(:disabled) {
+  filter: brightness(1.15);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 76, 84, 0.4);
+}
+
+.eagles-ics-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.eagles-direct-note {
+  font-size: 0.78rem !important;
+  color: var(--text-black-700);
+  opacity: 0.8;
+  padding-bottom: 0;
+  margin: 0;
+}
+
+.eagles-direct-status {
+  font-size: 0.88rem;
+  font-weight: 500;
+  min-height: 1.2em;
+  transition: all 0.3s ease;
+  border-radius: 6px;
+}
+
+.eagles-direct-status.status-loading { color: var(--text-black-700); }
+.eagles-direct-status.status-success {
+  color: #28a745;
+  background: rgba(40, 167, 69, 0.1);
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgba(40, 167, 69, 0.3);
+}
+.eagles-direct-status.status-error {
+  color: #dc3545;
+  background: rgba(220, 53, 69, 0.1);
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgba(220, 53, 69, 0.3);
+}
+
+.eagles-import-guide {
+  background: rgba(0, 76, 84, 0.08);
+  border: 1px solid rgba(0, 76, 84, 0.25);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-size: 0.83rem;
+  margin-top: 0.25rem;
+}
+
+.eagles-import-guide strong {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: var(--text-black-900);
+}
+
+.eagles-import-guide ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.eagles-import-guide li { color: var(--text-black-700); }
+
+/* ─── Divider between primary and email path ──────────────────────────── */
+.eagles-divider {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0.75rem 0;
+  color: var(--text-black-700);
+}
+
+.eagles-divider::before,
+.eagles-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--bg-black-50);
+}
+
+.eagles-divider span {
+  font-size: 0.8rem;
+  white-space: nowrap;
+  opacity: 0.7;
+}

--- a/styles/easter-eggs.css
+++ b/styles/easter-eggs.css
@@ -1,0 +1,245 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   Easter Egg Styles
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* ─── Toast notification ───────────────────────────────────────────────────── */
+.ee-toast {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(20px);
+  background: #1a1a2e;
+  color: #fff;
+  padding: 0.9rem 1.6rem;
+  border-radius: 50px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-align: center;
+  z-index: 9999;
+  opacity: 0;
+  border: 2px solid var(--skin-color);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  transition: opacity 0.35s ease, transform 0.35s ease;
+  pointer-events: none;
+  line-height: 1.5;
+}
+
+.ee-toast.ee-toast-show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.ee-idle-toast {
+  border-color: #4ecdc4;
+  font-size: 0.9rem;
+}
+
+/* ─── Confetti dots ────────────────────────────────────────────────────────── */
+.ee-confetti-dot {
+  position: fixed;
+  pointer-events: none;
+  z-index: 9998;
+  animation: ee-confetti-fly 1.3s ease-out forwards;
+  transform-origin: center;
+}
+
+@keyframes ee-confetti-fly {
+  0%   { transform: translate(0, 0) rotate(0deg) scale(1); opacity: 1; }
+  100% { transform: translate(var(--tx), var(--ty)) rotate(720deg) scale(0.3); opacity: 0; }
+}
+
+/* ─── HIRE ME overlay ──────────────────────────────────────────────────────── */
+#hire-me-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.82);
+  backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  opacity: 0;
+  transition: opacity 0.35s ease;
+}
+
+#hire-me-overlay.hire-me-visible {
+  opacity: 1;
+}
+
+.hire-me-box {
+  background: #1a1a1a;
+  border: 2px solid var(--skin-color);
+  border-radius: 20px;
+  padding: 2.5rem 3rem;
+  text-align: center;
+  max-width: 420px;
+  width: 90%;
+  box-shadow: 0 0 60px rgba(223, 167, 10, 0.25);
+  transform: scale(0.85);
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+#hire-me-overlay.hire-me-visible .hire-me-box {
+  transform: scale(1);
+}
+
+.hire-me-emoji {
+  font-size: 3.5rem;
+  margin-bottom: 0.5rem;
+  animation: hire-me-bounce 1s ease-in-out infinite alternate;
+}
+
+@keyframes hire-me-bounce {
+  from { transform: translateY(0); }
+  to   { transform: translateY(-10px); }
+}
+
+.hire-me-title {
+  font-size: 2.5rem;
+  font-weight: 900;
+  color: var(--skin-color);
+  letter-spacing: 0.05em;
+  margin-bottom: 0.3rem;
+  text-shadow: 0 0 20px rgba(223, 167, 10, 0.5);
+}
+
+.hire-me-subtitle {
+  font-size: 1rem;
+  color: #e9e9e9;
+  margin-bottom: 0.2rem;
+  padding-bottom: 0;
+}
+
+.hire-me-sub2 {
+  font-size: 0.85rem;
+  color: #888;
+  margin-bottom: 1.5rem;
+  padding-bottom: 0;
+}
+
+.hire-me-btn {
+  display: inline-block;
+  background: var(--skin-color);
+  color: #111;
+  font-weight: 700;
+  padding: 0.75rem 2rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-size: 1rem;
+  transition: all 0.25s ease;
+  margin-bottom: 1rem;
+}
+
+.hire-me-btn:hover {
+  filter: brightness(1.15);
+  transform: translateY(-2px);
+}
+
+.hire-me-close {
+  display: block;
+  margin: 0 auto;
+  background: none;
+  border: none;
+  color: #666;
+  font-size: 0.85rem;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+}
+
+.hire-me-close:hover { color: #aaa; }
+
+/* ─── Secret "hire" flash ──────────────────────────────────────────────────── */
+.ee-hire-flash {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.8);
+  background: rgba(51, 255, 153, 0.95);
+  color: #111;
+  font-size: 1.1rem;
+  font-weight: 800;
+  padding: 0.85rem 2rem;
+  border-radius: 999px;
+  z-index: 9999;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease, transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  white-space: nowrap;
+}
+
+.ee-hire-flash.ee-hire-flash-show {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+/* ─── Visitor badge ────────────────────────────────────────────────────────── */
+.visitor-badge {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-black-100);
+  border: 1px solid var(--bg-black-50);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.8rem;
+  color: var(--text-black-700);
+  z-index: 900;
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
+}
+
+.visitor-badge.vb-faded {
+  opacity: 0;
+  transform: translateY(6px);
+  pointer-events: none;
+}
+
+.vb-pulse {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #2ed573;
+  animation: vb-pulse-anim 1.8s ease infinite;
+  flex-shrink: 0;
+}
+
+@keyframes vb-pulse-anim {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(46, 213, 115, 0.6); }
+  50%       { box-shadow: 0 0 0 5px rgba(46, 213, 115, 0); }
+}
+
+.vb-text { display: flex; align-items: center; gap: 0.35rem; }
+.vb-sep  { opacity: 0.4; }
+.vb-global { display: flex; align-items: center; gap: 0.2rem; }
+
+/* ─── Welcome tip ──────────────────────────────────────────────────────────── */
+.vb-welcome-tip {
+  position: fixed;
+  bottom: 3.5rem;
+  left: 1rem;
+  background: var(--skin-color);
+  color: #111;
+  font-size: 0.82rem;
+  font-weight: 700;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  z-index: 901;
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  pointer-events: none;
+}
+
+.vb-welcome-tip.vb-welcome-show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ─── Mobile hide visitor badge ────────────────────────────────────────────── */
+@media (max-width: 600px) {
+  .visitor-badge { bottom: 0.6rem; left: 0.6rem; font-size: 0.72rem; }
+}

--- a/styles/easter-eggs.css
+++ b/styles/easter-eggs.css
@@ -239,7 +239,14 @@
   transform: translateY(0);
 }
 
-/* ─── Mobile hide visitor badge ────────────────────────────────────────────── */
-@media (max-width: 600px) {
-  .visitor-badge { bottom: 0.6rem; left: 0.6rem; font-size: 0.72rem; }
+/* ─── Visitor badge desktop offset (clear the fixed 18%-wide sidebar) ──────── */
+@media (min-width: 1100px) {
+  .visitor-badge   { left: calc(18% + 1.2rem); }
+  .vb-welcome-tip  { left: calc(18% + 1.2rem); }
+}
+
+/* ─── Mobile: sidebar collapses to top bar, badge sits at bottom-left ───────── */
+@media (max-width: 1099px) {
+  .visitor-badge   { bottom: 0.6rem; left: 0.6rem; font-size: 0.75rem; }
+  .vb-welcome-tip  { left: 0.6rem; }
 }

--- a/styles/fun-ui.css
+++ b/styles/fun-ui.css
@@ -1,0 +1,373 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   fun-ui.css  —  visual enhancements, animations, and personality
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* ─── Dot-grid texture on dark-mode backgrounds ──────────────────────────── */
+body.dark {
+  background-image: radial-gradient(rgba(255, 255, 255, 0.045) 1px, transparent 1px);
+  background-size: 28px 28px;
+}
+
+/* ─── Floating gradient orbs on the hero ─────────────────────────────────── */
+.need_job {
+  position: relative;
+  overflow: hidden;
+  min-height: 88dvh;
+}
+
+.need_job::before {
+  content: "";
+  position: absolute;
+  width: 560px;
+  height: 560px;
+  background: radial-gradient(circle, var(--skin-color), transparent 70%);
+  top: -180px;
+  right: -100px;
+  opacity: 0.08;
+  border-radius: 50%;
+  animation: hero-orb-float 11s ease-in-out infinite;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.need_job::after {
+  content: "";
+  position: absolute;
+  width: 380px;
+  height: 380px;
+  background: radial-gradient(circle, #6c5ce7, transparent 70%);
+  bottom: 60px;
+  left: -80px;
+  opacity: 0.06;
+  border-radius: 50%;
+  animation: hero-orb-float 15s ease-in-out infinite reverse;
+  pointer-events: none;
+  z-index: 0;
+}
+
+@keyframes hero-orb-float {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33%       { transform: translate(35px, -28px) scale(1.07); }
+  66%       { transform: translate(-22px, 18px) scale(0.94); }
+}
+
+/* make children appear above orbs */
+.need_job > * { position: relative; z-index: 1; }
+
+/* ─── Hero heading gradient text ─────────────────────────────────────────── */
+.asking_job h1 {
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  font-weight: 900;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  background: linear-gradient(135deg, var(--skin-color) 0%, #ff6b6b 55%, #a29bfe 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  cursor: help;
+}
+
+/* ─── "Open to Work" badge ───────────────────────────────────────────────── */
+.open-to-work-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  background: rgba(46, 213, 115, 0.1);
+  border: 1px solid rgba(46, 213, 115, 0.35);
+  color: #2ed573;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 0.75rem;
+}
+
+.otw-dot {
+  width: 8px;
+  height: 8px;
+  background: #2ed573;
+  border-radius: 50%;
+  flex-shrink: 0;
+  animation: otw-pulse 1.9s ease-in-out infinite;
+}
+
+@keyframes otw-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(46, 213, 115, 0.55); }
+  50%       { box-shadow: 0 0 0 5px rgba(46, 213, 115, 0); }
+}
+
+/* ─── Profession tech badges ─────────────────────────────────────────────── */
+.profession-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.35rem;
+  margin-bottom: 0.5rem;
+}
+
+.prof-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text-black-700);
+  padding: 0.28rem 0.7rem;
+  border-radius: 6px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  transition: border-color 0.25s ease, color 0.25s ease;
+}
+
+body:not(.dark) .prof-badge {
+  background: rgba(0, 0, 0, 0.04);
+  border-color: rgba(0, 0, 0, 0.1);
+}
+
+.prof-badge:hover {
+  border-color: var(--skin-color);
+  color: var(--skin-color);
+}
+
+/* ─── Hero staggered entrance ────────────────────────────────────────────── */
+@keyframes hero-slide-up {
+  from { opacity: 0; transform: translateY(28px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.need_job .cry_for_help  { animation: hero-slide-up 0.65s ease both 0.05s; }
+.need_job .asking_job    { animation: hero-slide-up 0.65s ease both 0.18s; }
+.need_job .contact-section { animation: hero-slide-up 0.65s ease both 0.32s; }
+
+/* ─── Section headings ─────────────────────────────────────────────────────
+
+   The h2 underline decorators still use --skin-color but we add a gradient
+   to the text itself in dark mode for flair.                                */
+body.dark .section_title h2 {
+  background: linear-gradient(130deg, #ffffff 55%, var(--skin-color) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  display: inline-block;
+}
+
+/* ─── Navigation sidebar improvements ───────────────────────────────────── */
+
+/* Side-bar accent bar on active/hover links */
+.aside .nav li a {
+  position: relative;
+  overflow: hidden;
+}
+
+.aside .nav li a::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 3px;
+  height: 65%;
+  background: var(--skin-color);
+  border-radius: 0 4px 4px 0;
+  transform: translateY(-50%) scaleY(0);
+  transform-origin: center;
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.aside .nav li a:hover::before,
+.aside .nav li a.active::before {
+  transform: translateY(-50%) scaleY(1);
+}
+
+/* ─── Logo shimmer animation ─────────────────────────────────────────────── */
+.aside .logo a {
+  background: linear-gradient(
+    90deg,
+    var(--text-black-900)  0%,
+    var(--skin-color)      45%,
+    var(--text-black-900)  90%
+  );
+  background-size: 250% auto;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  animation: logo-shimmer 5s linear infinite;
+}
+
+@keyframes logo-shimmer {
+  0%   { background-position: 200% center; }
+  100% { background-position: -50% center; }
+}
+
+/* ─── Project cards — gradient border shimmer on hover ───────────────────── */
+.project-card {
+  isolation: isolate;
+}
+
+.project-card::before {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: 15px;
+  background: linear-gradient(135deg, var(--skin-color), #6c5ce7 50%, #fd79a8);
+  opacity: 0;
+  z-index: -1;
+  transition: opacity 0.35s ease;
+}
+
+.project-card:hover::before { opacity: 1; }
+
+/* card inner bg needs to sit on top of the gradient border */
+.project-card:hover {
+  transform: translateY(-8px);
+  background: var(--project-card-bg);
+}
+
+/* ─── Image overlay gradient ─────────────────────────────────────────────── */
+.card-image-container {
+  position: relative;
+}
+
+.card-image-container::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 50%;
+  background: linear-gradient(to top, var(--project-card-bg), transparent);
+  pointer-events: none;
+}
+
+/* ─── Filter button glow on active ──────────────────────────────────────── */
+.filter-btn.active {
+  box-shadow: 0 0 14px rgba(223, 167, 10, 0.35);
+}
+
+/* ─── Skill description panel — glass + shimmer ─────────────────────────── */
+.skill-description-panel {
+  position: relative;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.03);
+  backdrop-filter: blur(8px);
+}
+
+/* top shimmer line */
+.skill-description-panel::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 60%;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--skin-color), transparent);
+  animation: panel-shimmer 4s ease-in-out infinite;
+}
+
+@keyframes panel-shimmer {
+  0%   { left: -60%; }
+  100% { left: 160%; }
+}
+
+/* ─── CRL stats card accent line ─────────────────────────────────────────── */
+.crl_card {
+  position: relative;
+  overflow: hidden;
+}
+
+.crl_card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--skin-color), #6c5ce7, #fd79a8);
+  border-radius: 14px 14px 0 0;
+}
+
+/* ─── Section-wide entrance animation ────────────────────────────────────── */
+@keyframes section-reveal {
+  from { opacity: 0; transform: translateY(18px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Use IntersectionObserver in JS, these classes get added when visible */
+.reveal { opacity: 0; }
+.reveal.is-visible { animation: section-reveal 0.6s ease forwards; }
+
+/* ─── Mobile contact links ────────────────────────────────────────────────── */
+.mobile_contact {
+  border-top: 1px solid var(--bg-black-50);
+  padding-top: 1rem;
+}
+
+.mobile_contact li a {
+  transition: color 0.2s ease, transform 0.2s ease;
+  display: inline-block;
+}
+
+.mobile_contact li a:hover {
+  transform: translateY(-2px);
+}
+
+/* ─── Scroll watcher gradient ─────────────────────────────────────────────── */
+.scroll_watcher {
+  background: linear-gradient(90deg, var(--skin-color), #6c5ce7, #fd79a8);
+}
+
+/* ─── Skill shelf bottom border glow ─────────────────────────────────────── */
+.shelf {
+  border-bottom-color: var(--skin-color);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2), 0 2px 0 var(--skin-color);
+}
+
+/* ─── Improved about section intro terminal look ─────────────────────────── */
+.cypher-text {
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.2);
+  border-left: 3px solid var(--skin-color);
+}
+
+body:not(.dark) .cypher-text {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+/* ─── Hover glow on email link ───────────────────────────────────────────── */
+.email-link:hover {
+  text-shadow: 0 0 12px rgba(0, 191, 255, 0.5);
+}
+
+/* ─── Soft glow on h3.hello name ─────────────────────────────────────────── */
+h3.hello span.name {
+  font-size: 3rem;
+}
+
+/* ─── CRL stat value pop on hover ────────────────────────────────────────── */
+.crl_stat_item:hover .crl_value {
+  color: var(--skin-color);
+  transition: color 0.2s ease;
+}
+
+/* ─── Better btn hover  ───────────────────────────────────────────────────── */
+.btn:hover {
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+/* ─── Tag color variation (fun rainbow tags) ──────────────────────────────── */
+.card-tag:nth-child(1)  { background: rgba(223, 167, 10,  0.15); color: #dfa70a; }
+.card-tag:nth-child(2)  { background: rgba(108, 92,  231, 0.15); color: #a29bfe; }
+.card-tag:nth-child(3)  { background: rgba(253, 121, 168, 0.15); color: #fd79a8; }
+.card-tag:nth-child(4)  { background: rgba(0,   184, 148, 0.15); color: #00b894; }
+.card-tag:nth-child(5)  { background: rgba(116, 185, 255, 0.15); color: #74b9ff; }
+.card-tag:nth-child(6)  { background: rgba(255, 107, 107, 0.15); color: #ff6b6b; }
+.card-tag:nth-child(n+7){ background: rgba(162, 155, 254, 0.15); color: #a29bfe; }
+
+/* ─── Media queries for fun-ui ────────────────────────────────────────────── */
+@media (max-width: 860px) {
+  .need_job::before { width: 300px; height: 300px; opacity: 0.06; }
+  .need_job::after  { display: none; }
+  .asking_job h1    { font-size: clamp(1.7rem, 7vw, 2.5rem); }
+}

--- a/styles/fun-ui.css
+++ b/styles/fun-ui.css
@@ -371,3 +371,43 @@ h3.hello span.name {
   .need_job::after  { display: none; }
   .asking_job h1    { font-size: clamp(1.7rem, 7vw, 2.5rem); }
 }
+
+/* ─── Improved section title styling ────────────────────────────────────────── */
+.section_title h2 {
+  letter-spacing: -0.01em;
+}
+
+/* ─── CRL stats grid: 3 cols on desktop ─────────────────────────────────────── */
+.crl_stats_grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1.25rem;
+}
+
+.crl_stat_item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0;
+}
+
+/* ─── Eagles card full-width on mobile ────────────────────────────────────────── */
+@media (max-width: 860px) {
+  .eagles.invite-card { flex-direction: column; }
+  .eagles .card-header { flex-wrap: wrap; gap: 0.5rem; }
+  .eagles .card-header h3 { font-size: 1rem !important; }
+}
+
+/* ─── NFL section mobile ──────────────────────────────────────────────────────── */
+@media (max-width: 600px) {
+  .nfl-section-title { font-size: 1.1rem !important; }
+  .nfl-toolbar { flex-direction: column; align-items: flex-start; gap: 0.5rem; }
+  .nfl-actions { flex-direction: column; }
+  .nfl-actions .nfl-btn { width: 100%; }
+}
+
+/* ─── Profession badges on mobile ─────────────────────────────────────────────── */
+@media (max-width: 480px) {
+  .profession-badges { gap: 0.25rem; }
+  .prof-badge { font-size: 0.68rem; padding: 0.18rem 0.45rem; }
+}

--- a/styles/nfl-calendar.css
+++ b/styles/nfl-calendar.css
@@ -1,0 +1,265 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   NFL Team Calendar Picker
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.nfl-calendar-section {
+  padding: 2rem 1rem 3rem;
+}
+
+/* ─── Header ─────────────────────────────────────────────────────────────── */
+.nfl-section-title {
+  font-size: 1.5rem !important;
+  font-weight: 700 !important;
+  margin-bottom: 0.25rem;
+}
+
+.nfl-section-sub {
+  color: var(--text-black-700);
+  font-size: 0.95rem;
+  margin-bottom: 1.5rem;
+}
+
+/* ─── Toolbar ─────────────────────────────────────────────────────────────── */
+.nfl-toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.nfl-toolbar-btn {
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  border: 2px solid var(--skin-color);
+  background: transparent;
+  color: var(--skin-color);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+
+.nfl-toolbar-btn:hover {
+  background: var(--skin-color);
+  color: #111;
+}
+
+.nfl-selected-count {
+  font-size: 0.88rem;
+  color: var(--text-black-700);
+  margin-left: auto;
+}
+
+/* ─── Division Groups ─────────────────────────────────────────────────────── */
+.nfl-teams-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-bottom: 2rem;
+}
+
+.nfl-division-group {
+  background: var(--bg-black-100);
+  border: 1px solid var(--bg-black-50);
+  border-radius: 12px;
+  padding: 1rem 1rem 0.75rem;
+}
+
+.nfl-division-title {
+  font-size: 0.75rem !important;
+  font-weight: 700 !important;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--skin-color);
+  margin-bottom: 0.75rem;
+}
+
+.nfl-division-teams {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+/* ─── Team Card ───────────────────────────────────────────────────────────── */
+.nfl-team-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.3rem;
+
+  width: 70px;
+  padding: 0.5rem 0.4rem 0.4rem;
+  border-radius: 10px;
+  border: 2px solid var(--bg-black-50);
+  background: var(--bg-black-900);
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  outline: none;
+}
+
+.nfl-team-card:hover {
+  transform: translateY(-3px);
+  border-color: var(--tc, var(--skin-color));
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
+}
+
+.nfl-team-card.nfl-selected {
+  border-color: var(--tc, var(--skin-color));
+  background: color-mix(in srgb, var(--tc, var(--skin-color)) 12%, var(--bg-black-900));
+  box-shadow: 0 0 0 2px var(--tc, var(--skin-color)) inset;
+}
+
+/* checkmark */
+.nfl-check-icon {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--tc, var(--skin-color));
+  color: #fff;
+  font-size: 0.6rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: scale(0);
+  transition: all 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.nfl-team-card.nfl-selected .nfl-check-icon {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.nfl-logo {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  pointer-events: none;
+}
+
+.nfl-abbr {
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--text-black-900);
+  letter-spacing: 0.03em;
+}
+
+/* ─── Action bar ──────────────────────────────────────────────────────────── */
+.nfl-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-top: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.nfl-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.7rem 1.4rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: all 0.25s ease;
+}
+
+.nfl-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.nfl-btn-primary {
+  background: var(--skin-color);
+  color: #111;
+  border-color: var(--skin-color);
+}
+
+.nfl-btn-primary:hover:not(:disabled) {
+  filter: brightness(1.12);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
+}
+
+.nfl-btn-ghost {
+  background: transparent;
+  border-color: var(--bg-black-50);
+  color: var(--text-black-700);
+}
+
+.nfl-btn-ghost:hover:not(:disabled) {
+  border-color: var(--skin-color);
+  color: var(--skin-color);
+}
+
+/* ─── Status message ──────────────────────────────────────────────────────── */
+.nfl-status-msg {
+  padding: 0.65rem 1rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  margin-top: 0.5rem;
+  transition: all 0.3s ease;
+}
+
+.nfl-status-loading { color: var(--text-black-700); }
+.nfl-status-success {
+  background: rgba(46, 213, 115, 0.12);
+  color: #2ed573;
+  border: 1px solid rgba(46, 213, 115, 0.3);
+}
+.nfl-status-error {
+  background: rgba(255, 71, 87, 0.12);
+  color: #ff6b81;
+  border: 1px solid rgba(255, 71, 87, 0.3);
+}
+.nfl-status-info {
+  background: rgba(0, 191, 255, 0.1);
+  color: #00bfff;
+  border: 1px solid rgba(0, 191, 255, 0.25);
+}
+
+/* ─── Import guide ────────────────────────────────────────────────────────── */
+.nfl-import-guide {
+  background: var(--bg-black-100);
+  border: 1px solid var(--bg-black-50);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  margin-top: 1rem;
+  font-size: 0.88rem;
+}
+
+.nfl-import-guide p {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: var(--text-black-900);
+  font-size: 0.9rem !important;
+  padding-bottom: 0;
+}
+
+.nfl-import-guide ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.nfl-import-guide li {
+  color: var(--text-black-700);
+  line-height: 1.4;
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────────────── */
+@media (max-width: 600px) {
+  .nfl-team-card { width: 60px; }
+  .nfl-logo { width: 32px; height: 32px; }
+}

--- a/styles/projectStyles.css
+++ b/styles/projectStyles.css
@@ -23,12 +23,13 @@
   background: transparent;
   border: 2px solid var(--skin-color);
   color: var(--skin-color);
-  padding: 0.6rem 1.25rem;
-  border-radius: 999px; /* Pill shape */
-  font-size: 0.9rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.3s ease;
+  transition: all 0.25s ease;
+  letter-spacing: 0.02em;
 }
 
 .filter-btn:hover {
@@ -318,3 +319,42 @@
 .modal-iframe.loaded {
   opacity: 1;
 }
+
+/* ── Pinned ribbon ─────────────────────────────────────────────────────────── */
+.project-card { position: relative; }
+
+.card-pinned-ribbon {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  font-size: 1.1rem;
+  z-index: 3;
+  animation: pin-swing 3s ease-in-out infinite;
+  transform-origin: top center;
+  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.4));
+}
+
+@keyframes pin-swing {
+  0%, 100% { transform: rotate(-4deg); }
+  50%       { transform: rotate(4deg); }
+}
+
+/* ── Card title hover underline ────────────────────────────────────────────── */
+.card-title {
+  position: relative;
+  display: inline-block;
+}
+
+.card-title::after {
+  content: "";
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  width: 0;
+  height: 2px;
+  background: var(--skin-color);
+  border-radius: 999px;
+  transition: width 0.3s ease;
+}
+
+.project-card:hover .card-title::after { width: 100%; }

--- a/styles/skills_Styles.css
+++ b/styles/skills_Styles.css
@@ -137,3 +137,35 @@
     transform: translateY(0);
   }
 }
+
+/* ── Panel content pop animation when a new skill is hovered ── */
+@keyframes panel-content-pop {
+  0%   { opacity: 0; transform: translateY(6px) scale(0.98); }
+  100% { opacity: 1; transform: translateY(0)   scale(1);    }
+}
+
+.skill-description-panel.panel-pop {
+  animation: panel-content-pop 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+/* ── Bigger, more readable book spines ── */
+.book {
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+}
+
+/* ── Shelf title badge look ── */
+.shelf-title {
+  font-size: 0.7rem !important;
+  font-weight: 800 !important;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 4px;
+  padding: 0.2rem 0.5rem;
+  display: inline-block;
+  margin-bottom: 0.5rem;
+  letter-spacing: 0.1em;
+}
+
+body:not(.dark) .shelf-title {
+  background: rgba(0, 0, 0, 0.06);
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -162,22 +162,22 @@ h2 {
   content: "";
   height: 4px;
   width: 50px;
-  background-color: var(--skin-color);
+  background: linear-gradient(90deg, var(--skin-color), #6c5ce7);
   position: absolute;
   bottom: 0;
-  /* left: 0; */
+  left: 0;
+  border-radius: 999px;
 }
 
 .section_title h2::after {
   content: "";
   height: 4px;
   width: 25px;
-  background-color: var(--skin-color);
+  background: linear-gradient(90deg, #6c5ce7, #fd79a8);
   position: absolute;
-  /* bottom: -3; */
-  /* left: 0; */
   bottom: -8px;
   left: 0;
+  border-radius: 999px;
 }
 
 .row {


### PR DESCRIPTION
Eagles Calendar:
- Add primary "Download Eagles Schedule (.ics)" button powered by ESPN live API
  (always current — no manual schedule updates ever needed)
- Add styled import guide (Apple Calendar / Google Calendar / Outlook)
- Add divider separating direct download from email invite path
- Fix fetch redirect handling and improve error message in email path

NFL Team Calendar Picker (new section):
- All 32 teams grouped by division with ESPN logo images
- Multi-select with team-color checkmark indicators
- "Select All 32" and "Clear" controls
- Fetches live schedules from ESPN public API (no API key needed)
- Deduplicates shared games across multiple selected teams
- Generates and downloads a standard .ics file compatible with all calendar apps
- Status messages and collapsible import guide after download
- Fully responsive grid layout

Easter Eggs:
- Console ASCII art + recruitment message on page load
- Konami Code (↑↑↓↓←→←→BA) triggers confetti party + toast
- Logo clicked 5× in quick succession → animated "HIRE ME" overlay with confetti
- Type "hire" anywhere on the page → green flash notification
- Idle for 45s → cheeky rotating messages appear

Visitor Tracking:
- Per-device visit counter and first-visit date via localStorage
- Global hit counter via CountAPI (free, no auth, graceful fallback)
- Subtle badge bottom-left with pulsing green dot; fades out on scroll
- First-visit welcome tip shown once

https://claude.ai/code/session_01ADNAYMar8TbZkUckDBmoPu